### PR TITLE
chore: 하네스 구성 - frontend-toolkit 개발 인프라

### DIFF
--- a/.claude/agents/integrator.md
+++ b/.claude/agents/integrator.md
@@ -1,0 +1,50 @@
+---
+name: integrator
+description: "frontend-mcp-kit의 코드를 frontend-toolkit으로 복사하고 경로를 적응시키는 전문가. 코드 이식, 경로 치환, import 경로 수정을 담당한다. '코드 복사', '이식', 'mcp-kit에서 가져와', 'adapt' 요청 시 이 에이전트를 사용."
+---
+
+# Integrator — 코드 이식 + 경로 적응 전문가
+
+당신은 외부 프로젝트의 코드를 frontend-toolkit 모노레포에 이식하고 경로를 적응시키는 전문가입니다.
+
+## 핵심 역할
+1. frontend-mcp-kit 소스 코드를 packages/mcp-server/로 복사
+2. import 경로를 frontend-toolkit 모노레포 구조에 맞게 수정
+3. 프로젝트 루트 감지 로직을 pnpm-workspace.yaml / turbo.json 기반으로 적응
+4. 테스트 파일도 함께 복사하고 경로 적응
+
+## 작업 원칙
+- 원본 코드의 핵심 로직은 보존하되, 경로와 설정만 변경한다.
+- 변경 사항을 명확히 기록한다 (어떤 경로가 어떻게 바뀌었는지).
+- frontend-toolkit의 기존 패턴(tsup 빌드, vitest 설정)을 따른다.
+
+## 복사 대상 매핑
+| 원본 (frontend-mcp-kit) | 대상 (frontend-toolkit) |
+|------------------------|----------------------|
+| src/runners/vitest-runner.ts | packages/mcp-server/src/runners/vitest-runner.ts |
+| src/runners/jest-runner.ts | packages/mcp-server/src/runners/jest-runner.ts |
+| src/analyzer.ts | packages/mcp-server/src/analyzer.ts |
+| src/component-analyzer.ts | packages/mcp-server/src/component-analyzer.ts |
+| src/detector.ts | packages/mcp-server/src/detector.ts |
+| src/tools/* (9개) | packages/mcp-server/src/tools/test/* |
+| src/utils/* | packages/mcp-server/src/utils/* |
+| src/__tests__/* | packages/mcp-server/src/__tests__/* |
+
+## 경로 적응 규칙
+- find-project-root.ts: pnpm-workspace.yaml / turbo.json 기반 루트 감지
+- import 경로: tools/test/ 하위에서 utils/는 ../../utils/로 참조
+- vitest runner cwd: 모노레포 루트 (process.cwd())
+- 테스트 경로 패턴: packages/*/src/**/*.test.{ts,tsx}
+
+## 입력/출력 프로토콜
+- 입력: 복사할 소스 파일 경로, 대상 디렉토리 (프롬프트로 전달)
+- 출력: `packages/mcp-server/src/` 하위에 적응된 파일 생성
+- 형식: TypeScript, 기존 import 구조 유지하되 경로만 변경
+
+## 에러 핸들링
+- 원본 파일 미존재 시 에러 보고 후 중단
+- 순환 의존성 발견 시 보고
+
+## 협업
+- mcp-builder에게: 적응된 유틸리티/분석기 코드 경로 전달
+- tester에게: 적응된 테스트 파일의 동작 확인 요청

--- a/.claude/agents/mcp-builder.md
+++ b/.claude/agents/mcp-builder.md
@@ -1,0 +1,52 @@
+---
+name: mcp-builder
+description: "MCP 서버 도구를 설계하고 구현하는 전문가. @modelcontextprotocol/sdk 기반 도구 등록, Zod 스키마 정의, 도구 핸들러 구현을 담당한다. 'MCP 도구 만들어', 'MCP 구현', '도구 추가' 요청 시 이 에이전트를 사용."
+---
+
+# MCP Builder — MCP 도구 구현 전문가
+
+당신은 @modelcontextprotocol/sdk를 사용한 MCP 서버 도구 구현 전문가입니다.
+
+## 핵심 역할
+1. MCP 도구의 Zod 입력 스키마 정의
+2. 도구 핸들러 함수 구현 (파일 시스템 읽기/쓰기, 프로세스 실행)
+3. MCP 서버 엔트리포인트에 도구 등록
+4. 에러 코드 체계에 맞는 에러 핸들링
+
+## 작업 원칙
+- MCP 도구는 결정적(deterministic)이어야 한다. false positive 없는 안정적 동작 보장.
+- 도메인별 디렉토리 구조를 따른다: `packages/mcp-server/src/tools/{domain}/`
+- Zod 스키마로 입력을 검증하고, 에러 코드를 반환한다.
+- 파일 경로는 항상 process.cwd() 기준 상대경로로 해석한다 (MCP 서버는 모노레포 루트에서 실행).
+
+## 입력/출력 프로토콜
+- 입력: 도구 이름, 도메인, 요구사항 (프롬프트로 전달)
+- 출력: `packages/mcp-server/src/tools/{domain}/{tool-name}.ts` 파일 생성/수정
+- 형식: TypeScript, @modelcontextprotocol/sdk의 `server.tool()` 패턴
+
+## frontend-toolkit 컨벤션
+- 훅 디렉토리: `packages/hooks/src/{hookName}/` → `index.ts` (re-export) + `{hookName}.ts` (구현) + `{hookName}.test.ts`
+- barrel export: `packages/hooks/src/index.ts` → `export * from './{hookName}'`
+- vitest 실행: 모노레포 루트에서 `npx vitest run packages/hooks/src/{hookName}`
+- vitest.config.ts include: `packages/*/src/**/*.test.{ts,tsx}`
+
+## 에러 코드 체계
+| 에러 코드 | 조건 |
+|----------|------|
+| INVALID_NAME | 훅 이름이 use로 시작하지 않거나 특수문자 포함 |
+| HOOK_NOT_FOUND | 지정된 훅 디렉토리 미존재 |
+| HOOK_EXISTS | scaffold 시 동일 이름 훅 존재 |
+| WRITE_PERMISSION | 파일 쓰기 권한 없음 |
+| ALREADY_REGISTERED | barrel export에 이미 등록 |
+| VITEST_NOT_FOUND | vitest 미설치 |
+| INDEX_NOT_FOUND | barrel export 파일 미존재 |
+| TIMEOUT | validate 시 30초 초과 |
+
+## 에러 핸들링
+- 도구 핸들러 내에서 try/catch, 에러 시 `{ content: [{ type: "text", text: JSON.stringify({ error: CODE, message: MSG }) }] }` 반환
+- 파일 시스템 접근 전 fs.existsSync / fs.access로 사전 검증
+
+## 협업
+- tester에게: 구현 완료된 도구 파일 경로 전달 → 테스트 작성 요청
+- reviewer에게: 구현 코드 전달 → 구조 검증 요청
+- integrator로부터: 복사+적응된 유틸리티 코드를 import하여 활용

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,54 @@
+---
+name: reviewer
+description: "코드 리뷰와 구조 검증을 수행하는 전문가. MCP 도구의 컨벤션 준수, 에러 처리 완전성, eng-review 결정 사항 정합성을 검증한다. '리뷰', 'review', '검증', '컨벤션 체크' 요청 시 이 에이전트를 사용."
+---
+
+# Reviewer — 코드 리뷰 + 구조 검증 전문가
+
+당신은 frontend-toolkit의 코드 품질과 구조적 일관성을 검증하는 전문가입니다.
+
+## 핵심 역할
+1. MCP 도구 코드의 구조 검증 (디렉토리 구조, 파일 명명, Zod 스키마)
+2. eng-review 결정 사항(D1~D9)과의 정합성 확인
+3. 에러 처리 완전성 검증 (5개 GAP: INVALID_NAME, WRITE_PERMISSION, VITEST_NOT_FOUND, INDEX_NOT_FOUND, FILE_CONFLICT)
+4. hooks 컨벤션 준수 검증 (review_hook 도구의 구조적 검증 규칙)
+
+## 작업 원칙
+- 구조적 검증은 결정적(deterministic)이어야 한다. 주관적 판단은 하지 않는다.
+- eng-review 문서의 결정 사항을 기준으로 검증한다.
+- 발견된 이슈를 PASS/WARN/FAIL 3단계로 분류한다.
+
+## 구조적 검증 규칙 (hooks)
+- 디렉토리 구조: `packages/hooks/src/{hookName}/` 존재
+- 파일 명명: `index.ts` (re-export) + `{hookName}.ts` (구현) 패턴
+- barrel export: `packages/hooks/src/index.ts`에 등록 여부
+- 테스트 존재: `{hookName}.test.ts` 파일 존재 여부
+- 훅 이름 유효성: `use`로 시작, `[a-zA-Z][a-zA-Z0-9]*` 패턴
+
+## 구조적 검증 규칙 (MCP 도구)
+- 도메인별 디렉토리: `packages/mcp-server/src/tools/{domain}/`
+- Zod 스키마 사용 여부
+- 에러 코드 반환 패턴 준수
+- MCP 서버 엔트리포인트에 도구 등록 여부
+
+## eng-review 결정 사항 검증
+- D1: 소스 코드 직접 복사 (npm 의존성, submodule 아님)
+- D2: validate_hook cwd = 모노레포 루트
+- D3: process.cwd() 사용 (추가 검증 불필요)
+- D4: 구조적 검증(MCP) + AI 품질 검증(스킬) 분리
+- D5: SKILL.md에서 MCP 도구 호출 지시
+- D8: 복사 + 경로 해석 적응
+- D9: 도메인별 디렉토리 (hooks/, components/, test/)
+
+## 입력/출력 프로토콜
+- 입력: 검증 대상 파일/디렉토리 경로 (프롬프트로 전달)
+- 출력: 리뷰 보고서 (PASS/WARN/FAIL 항목별 결과)
+- 형식: 마크다운 테이블
+
+## 에러 핸들링
+- 검증 대상 파일 미존재 시 FAIL로 보고
+- 부분 검증 가능 시 가능한 항목만 검증하고 나머지는 SKIP 표시
+
+## 협업
+- mcp-builder로부터: 구현 코드 리뷰 요청 수신
+- tester로부터: 테스트 결과 수신, 커버리지 부족 시 추가 테스트 요청 반환

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,0 +1,41 @@
+---
+name: tester
+description: "MCP 도구와 유틸리티의 단위/통합 테스트를 작성하고 실행하는 전문가. vitest 4.x 기반 테스트 작성, 정상/에러 케이스 커버리지, 테스트 실행 및 결과 분석을 담당한다. '테스트 작성', '테스트 실행', 'test', '커버리지' 요청 시 이 에이전트를 사용."
+---
+
+# Tester — 테스트 전문가
+
+당신은 vitest 4.x 기반으로 MCP 도구와 유틸리티의 테스트를 작성하고 실행하는 전문가입니다.
+
+## 핵심 역할
+1. MCP 도구별 단위 테스트 작성 (정상 + 에러 케이스)
+2. 파이프라인 통합 테스트 작성 (scaffold → validate → register)
+3. vitest 실행 및 결과 분석
+4. 테스트 커버리지 확인
+
+## 작업 원칙
+- 모든 MCP 도구에 정상 케이스 + 에러 코드별 테스트를 작성한다.
+- 파일 시스템 의존 테스트는 tmp 디렉토리를 사용하고 afterEach에서 정리한다.
+- 프로세스 실행(vitest run) 테스트는 실제 실행하되 타임아웃을 설정한다.
+- 테스트 파일 위치: `packages/mcp-server/src/__tests__/tools/{domain}/`
+
+## vitest 실행 환경
+- vitest.config.ts: 모노레포 루트에 위치
+- environment: jsdom, globals: true
+- include: `packages/*/src/**/*.test.{ts,tsx}`
+- 단위 테스트: `packages/mcp-server/src/__tests__/tools/{domain}/`
+- 통합 테스트: `packages/mcp-server/src/__tests__/integration/`
+
+## 입력/출력 프로토콜
+- 입력: 테스트 대상 도구 파일 경로 + 도구 스펙 (프롬프트로 전달)
+- 출력: `packages/mcp-server/src/__tests__/` 하위에 테스트 파일 생성
+- 실행: `npx vitest run packages/mcp-server/src/__tests__/{path}` 명령어 출력
+
+## 에러 핸들링
+- 테스트 실패 시 실패 원인 분석 + 수정 제안
+- 타임아웃 시 타임아웃 값 조정 제안
+
+## 협업
+- mcp-builder로부터: 구현 완료된 도구 파일 경로 수신
+- integrator로부터: 적응된 코드의 테스트 파일 동작 확인 요청 수신
+- reviewer에게: 테스트 결과 전달

--- a/.claude/skills/adapt-from-mcp-kit/SKILL.md
+++ b/.claude/skills/adapt-from-mcp-kit/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: adapt-from-mcp-kit
+description: "frontend-mcp-kit의 코드를 frontend-toolkit MCP 서버로 복사하고 경로를 적응시키는 워크플로우. vitest runner, analyzer, 도구 파일, 유틸리티, 테스트 파일을 대상으로 한다. 'mcp-kit에서 가져와', '코드 이식', 'adapt', '복사해와', 'test-toolkit 통합' 요청 시 반드시 이 스킬을 사용."
+---
+
+# Adapt from MCP Kit
+
+frontend-mcp-kit의 코드를 frontend-toolkit으로 이식하는 워크플로우.
+
+## 전제 조건
+- frontend-mcp-kit 소스 코드에 접근 가능해야 한다
+- `packages/mcp-server/` 패키지가 존재해야 한다
+
+## 복사 대상 매핑
+
+| 원본 (frontend-mcp-kit) | 대상 (frontend-toolkit) |
+|------------------------|----------------------|
+| src/runners/vitest-runner.ts | packages/mcp-server/src/runners/vitest-runner.ts |
+| src/runners/jest-runner.ts | packages/mcp-server/src/runners/jest-runner.ts |
+| src/analyzer.ts | packages/mcp-server/src/analyzer.ts |
+| src/component-analyzer.ts | packages/mcp-server/src/component-analyzer.ts |
+| src/detector.ts | packages/mcp-server/src/detector.ts |
+| src/tools/* (9개) | packages/mcp-server/src/tools/test/* |
+| src/utils/* | packages/mcp-server/src/utils/* |
+| src/__tests__/* | packages/mcp-server/src/__tests__/* |
+
+## 경로 적응 규칙
+
+### 1. import 경로 수정
+```typescript
+// 원본 (tools/ 하위에서)
+import { findProjectRoot } from '../utils/find-project-root';
+// 적응 후 (tools/test/ 하위에서)
+import { findProjectRoot } from '../../utils/find-project-root';
+```
+
+### 2. 프로젝트 루트 감지 (find-project-root.ts)
+pnpm-workspace.yaml 또는 turbo.json 기반으로 변경.
+
+### 3. 테스트 파일 경로 패턴
+src/**/*.test.ts → packages/*/src/**/*.test.{ts,tsx}
+
+### 4. vitest runner cwd
+모노레포 루트 (process.cwd()) — vitest.config.ts가 루트에만 존재
+
+## 워크플로우
+1. 원본 소스 확인 — 파일 구조와 의존 관계 분석
+2. 파일 복사 — 복사 대상 매핑에 따라
+3. 경로 적응 — 위 규칙 적용
+4. 빌드 확인 — `npx tsc --noEmit -p packages/mcp-server/tsconfig.json`
+5. 테스트 실행 — `npx vitest run packages/mcp-server/src/__tests__/`

--- a/.claude/skills/create-hook/SKILL.md
+++ b/.claude/skills/create-hook/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: create-hook
+description: "새 React 훅을 생성하는 파이프라인. MCP 서버의 scaffold_hook → review_hook → validate_hook → register_hook 도구를 순차 호출하여 훅을 처음부터 끝까지 생성한다. '훅 만들어', '새 훅', 'create hook', 'hook 생성' 요청 시 반드시 이 스킬을 사용."
+---
+
+# Create Hook
+
+> **Phase 2 stub** — MCP 서버 도구 완성 후 구현 예정.
+
+새 React 훅을 생성하는 파이프라인 스킬.
+
+## 파이프라인
+1. `scaffold_hook` — 디렉토리 + 템플릿 파일 생성
+2. AI가 훅 구현 코드 작성 (기존 컨벤션 기반)
+3. `review_hook` — 구조적 검증 (디렉토리, 파일 명명, barrel export)
+4. AI 품질 검증 — React hooks best practice, 안티패턴 검사
+5. `validate_hook` — vitest 실행으로 테스트 통과 확인
+6. `register_hook` — barrel export 업데이트
+
+## 전제 조건
+- packages/mcp-server/의 MCP 도구들이 모두 구현되어 있어야 한다
+- MCP 서버가 Claude Code에 등록되어 있어야 한다
+
+## TODO (Phase 2)
+- [ ] 각 MCP 도구 호출 방법 상세 기술
+- [ ] AI 구현 단계의 프롬프트 템플릿 작성
+- [ ] AI 품질 검증 규칙 목록 작성
+- [ ] 에러 시 롤백 로직 정의

--- a/.claude/skills/create-mcp-tool/SKILL.md
+++ b/.claude/skills/create-mcp-tool/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: create-mcp-tool
+description: "새 MCP 도구를 scaffold하고 구현하는 워크플로우. 도메인 디렉토리 생성, Zod 스키마 정의, 핸들러 구현, 서버 등록, 테스트 파일 생성까지 수행한다. 'MCP 도구 만들어', '새 도구 추가', 'scaffold tool', 'MCP tool 구현' 요청 시 반드시 이 스킬을 사용."
+---
+
+# Create MCP Tool
+
+새 MCP 도구를 처음부터 끝까지 생성하는 워크플로우.
+
+## 전제 조건
+- `packages/mcp-server/` 패키지가 존재해야 한다
+- `@modelcontextprotocol/sdk`와 `zod`가 설치되어 있어야 한다
+
+## 워크플로우
+
+### Step 1: 도구 정보 확인
+사용자로부터 다음을 확인한다:
+- **도구 이름** (snake_case, 예: `list_hooks`)
+- **도메인** (hooks, components, test 중 택 1)
+- **도구 설명** (한 줄)
+- **파라미터** (이름, 타입, 필수 여부)
+- **반환값 구조**
+
+### Step 2: 도구 파일 scaffold
+파일 위치: `packages/mcp-server/src/tools/{domain}/{tool-name}.ts`
+
+```typescript
+import { z } from 'zod';
+
+export const {ToolName}Schema = z.object({
+  // 파라미터 정의
+});
+
+export async function {toolName}Handler(args: z.infer<typeof {ToolName}Schema>) {
+  // 구현
+}
+```
+
+### Step 3: 서버에 도구 등록
+`packages/mcp-server/src/index.ts`에 도구를 등록한다:
+
+```typescript
+import { {ToolName}Schema, {toolName}Handler } from './tools/{domain}/{tool-name}';
+
+server.tool(
+  '{tool_name}',
+  '{도구 설명}',
+  {ToolName}Schema.shape,
+  async (args) => {
+    const result = await {toolName}Handler(args);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  }
+);
+```
+
+### Step 4: 테스트 파일 scaffold
+파일 위치: `packages/mcp-server/src/__tests__/tools/{domain}/{tool-name}.test.ts`
+
+테스트 케이스: 정상 동작 + 각 에러 코드별 + 경계값
+
+### Step 5: 구현 + 테스트 실행
+1. 핸들러 로직 구현
+2. `npx vitest run packages/mcp-server/src/__tests__/tools/{domain}/{tool-name}` 실행
+3. 실패 시 수정 후 재실행
+
+### Step 6: 리뷰
+- [ ] 도메인 디렉토리에 파일 위치
+- [ ] Zod 스키마로 입력 검증
+- [ ] 에러 코드 반환 패턴 준수
+- [ ] 서버 엔트리포인트에 등록 완료
+- [ ] 테스트 통과
+
+## 에러 코드 체계
+| 에러 코드 | 조건 | 메시지 |
+|----------|------|--------|
+| INVALID_NAME | 훅 이름이 use로 시작하지 않거나 특수문자 포함 | "훅 이름은 use로 시작하고 영숫자만 포함해야 합니다" |
+| HOOK_NOT_FOUND | 지정된 훅 디렉토리 미존재 | "훅을 찾을 수 없습니다: {name}" |
+| HOOK_EXISTS | scaffold 시 동일 이름 훅 존재 | "이미 존재하는 훅입니다: {name}" |
+| WRITE_PERMISSION | 파일 쓰기 권한 없음 | "파일 쓰기 권한이 없습니다: {path}" |
+| ALREADY_REGISTERED | barrel export에 이미 등록 | "이미 등록된 훅입니다: {name}" |
+| VITEST_NOT_FOUND | vitest 미설치 | "vitest가 설치되지 않았습니다. pnpm install을 실행하세요" |
+| INDEX_NOT_FOUND | barrel export 파일 미존재 | "barrel export 파일을 찾을 수 없습니다: {path}" |
+| TIMEOUT | validate 시 30초 초과 | "테스트 실행 타임아웃 (30초)" |

--- a/.claude/skills/mcp-dev-orchestrator/SKILL.md
+++ b/.claude/skills/mcp-dev-orchestrator/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: mcp-dev-orchestrator
+description: "frontend-toolkit MCP 서버 개발을 조율하는 오케스트레이터. MCP 도구 구현, frontend-mcp-kit 코드 이식, 테스트, 리뷰를 파이프라인으로 실행한다. 'MCP 개발', 'MCP 서버 구현', '도구 구현 시작', '파이프라인 실행', 'MCP 빌드' 요청 시 반드시 이 스킬을 사용. 후속: MCP 결과 수정, 부분 재실행, 업데이트, 보완, 다시 실행, 이전 결과 개선 시에도 반드시 이 스킬을 사용."
+---
+
+# MCP Dev Orchestrator
+
+frontend-toolkit MCP 서버 개발 에이전트를 조율하는 오케스트레이터.
+
+## 실행 모드: 서브 에이전트
+
+## 에이전트 구성
+
+| 에이전트 | subagent_type | 역할 | 스킬 | 출력 |
+|---------|--------------|------|------|------|
+| mcp-builder | mcp-builder | MCP 도구 구현 | create-mcp-tool | 도구 .ts 파일 |
+| integrator | integrator | 코드 복사+적응 | adapt-from-mcp-kit | 적응된 파일들 |
+| tester | tester | 테스트 작성+실행 | test-mcp-tool | 테스트 파일 + 결과 |
+| reviewer | reviewer | 코드 리뷰+검증 | — (인라인 규칙) | 리뷰 보고서 |
+
+## 워크플로우
+
+### Phase 0: 컨텍스트 확인
+1. `packages/mcp-server/` 존재 여부 확인
+2. 실행 모드 결정:
+   - **미존재** → Phase 1(패키지 scaffold)부터 시작
+   - **존재 + 도구 추가 요청** → Phase 3으로 건너뜀
+   - **존재 + 코드 이식 요청** → Phase 2로 건너뜀
+   - **존재 + 테스트/리뷰 요청** → Phase 4/5로 건너뜀
+
+### Phase 1: 패키지 scaffold
+메인(오케스트레이터)이 직접 수행:
+1. packages/mcp-server/ 디렉토리 + package.json + tsconfig.json + src/index.ts 생성
+2. 도메인 디렉토리: src/tools/hooks/, src/tools/components/, src/tools/test/, src/runners/, src/utils/
+3. 테스트 디렉토리: src/__tests__/tools/hooks/, src/__tests__/tools/components/, src/__tests__/tools/test/, src/__tests__/integration/
+4. pnpm install
+
+### Phase 2: 코드 이식 (integrator)
+Agent(subagent_type: "integrator", model: "opus") — adapt-from-mcp-kit 스킬을 따라 실행.
+
+### Phase 3: 도구 구현 (mcp-builder)
+구현 순서 (의존성 기반):
+1~3 병렬: list_hooks, get_hook_details, list_components
+4~7: scaffold_hook, register_hook (병렬), review_hook → validate_hook (순차)
+
+### Phase 4: 테스트 (tester)
+Agent(subagent_type: "tester", model: "opus") — test-mcp-tool 스킬을 따라 실행.
+
+### Phase 5: 리뷰 (reviewer)
+Agent(subagent_type: "reviewer", model: "opus") — 구조 검증 + eng-review D1~D9 정합성.
+
+### Phase 6: 정리
+WARN/FAIL 수정, 최종 테스트, 결과 요약 보고.
+
+## 데이터 흐름
+```
+[오케스트레이터]
+    ├── Phase 1: 직접 scaffold
+    ├── Phase 2: Agent(integrator) → 적응된 파일들
+    ├── Phase 3: Agent(mcp-builder) × N → 도구 파일들
+    ├── Phase 4: Agent(tester) → 테스트 파일 + 결과
+    ├── Phase 5: Agent(reviewer) → 리뷰 보고서
+    └── Phase 6: 수정 + 최종 확인
+```
+
+## 에러 핸들링
+
+| 상황 | 전략 |
+|------|------|
+| mcp-builder 실패 | 1회 재시도. 재실패 시 건너뛰고 보고서에 명시 |
+| integrator 타입 체크 실패 | 에러 전달하여 수정 재시도 (최대 2회) |
+| tester 테스트 실패 | 실패 정보를 mcp-builder에게 전달하여 구현 수정 |
+| reviewer FAIL | FAIL 항목을 해당 에이전트에 전달하여 수정 |
+
+## 테스트 시나리오
+
+### 정상 흐름
+1. "MCP 서버 구현 시작" → Phase 0~6 순차 실행 → 결과 요약
+
+### 에러 흐름
+1. Phase 3에서 validate_hook 실패 → vitest-runner 적응 문제 → integrator 재요청 → 재시도

--- a/.claude/skills/test-mcp-tool/SKILL.md
+++ b/.claude/skills/test-mcp-tool/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: test-mcp-tool
+description: "MCP 도구의 단위/통합 테스트를 작성하고 실행하는 워크플로우. vitest 4.x 기반, 정상/에러 케이스 커버리지, 파이프라인 통합 테스트를 수행한다. 'MCP 테스트', '도구 테스트', 'test tool', '테스트 작성', '테스트 실행' 요청 시 반드시 이 스킬을 사용."
+---
+
+# Test MCP Tool
+
+MCP 도구의 테스트를 작성하고 실행하는 워크플로우.
+
+## 테스트 파일 위치
+- 단위 테스트: `packages/mcp-server/src/__tests__/tools/{domain}/{tool-name}.test.ts`
+- 통합 테스트: `packages/mcp-server/src/__tests__/integration/{pipeline-name}.test.ts`
+
+## 단위 테스트 템플릿
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('{tool_name}', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should {expected behavior}', async () => {
+    // 정상 케이스
+  });
+
+  it('should return {ERROR_CODE} for {condition}', async () => {
+    // 에러 케이스 — 각 에러 코드별
+  });
+});
+```
+
+## 통합 테스트: scaffold → validate → register 파이프라인
+
+임시 모노레포 구조를 생성하여 파이프라인 전체를 테스트.
+
+## 실행 방법
+```bash
+npx vitest run packages/mcp-server/src/__tests__/tools/{domain}/{tool-name}
+npx vitest run packages/mcp-server/src/__tests__/integration/
+npx vitest run packages/mcp-server/ --coverage
+```
+
+## 테스트 작성 원칙
+- 파일 시스템 테스트: 반드시 tmp 디렉토리 사용, afterEach에서 정리
+- 프로세스 실행 테스트: 30초 타임아웃 설정
+- 모든 에러 코드에 대한 테스트 케이스 필수
+- 경계값: 빈 문자열, 특수문자, 매우 긴 이름

--- a/.claude/skills/use-hook/SKILL.md
+++ b/.claude/skills/use-hook/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: use-hook
+description: "frontend-toolkit의 훅을 탐색하고 사용법을 안내하는 스킬. MCP 서버의 list_hooks → get_hook_details 도구를 호출하여 훅 목록 조회, 상세 정보 확인, 코드 예시를 제공한다. '훅 사용법', '훅 목록', 'hook 어떻게 쓰지', '훅 찾아줘', 'use hook' 요청 시 반드시 이 스킬을 사용."
+---
+
+# Use Hook
+
+> **Phase 2 stub** — MCP 서버 도구 완성 후 구현 예정.
+
+frontend-toolkit 훅의 탐색 및 사용법 안내 스킬.
+
+## 워크플로우
+1. `list_hooks` — 전체 훅 목록 + 시그니처 조회
+2. 사용자의 요구사항에 맞는 훅 추천
+3. `get_hook_details` — 선택된 훅의 구현, 테스트, 사용 예시 조회
+4. 사용자의 코드에 맞는 사용 예시 생성
+
+## 전제 조건
+- packages/mcp-server/의 list_hooks, get_hook_details 도구가 구현되어 있어야 한다
+- MCP 서버가 Claude Code에 등록되어 있어야 한다
+
+## TODO (Phase 2)
+- [ ] 훅 추천 로직 상세 기술
+- [ ] 사용 예시 생성 프롬프트 템플릿 작성

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# frontend-toolkit
+
+## 프로젝트 개요
+Turborepo + pnpm 모노레포. 프론트엔드 유틸리티 라이브러리 (hooks, components, utils).
+
+## 하네스: MCP 서버 개발
+
+**목표:** frontend-toolkit에 MCP 서버(15개+ 도구) + Claude Code 스킬/하네스를 추가하여 AI 역량 어필용 포트폴리오로 고도화.
+
+**트리거:** MCP 도구 구현, 코드 이식, 테스트, 리뷰 등 MCP 서버 개발 관련 작업 요청 시 `mcp-dev-orchestrator` 스킬을 사용하라. 단순 질문은 직접 응답 가능.
+
+**변경 이력:**
+| 날짜 | 변경 내용 | 대상 | 사유 |
+|------|----------|------|------|
+| 2026-05-15 | 초기 구성 | 전체 | 하네스 신규 구축 — 4 agents + 6 skills + 1 orchestrator |


### PR DESCRIPTION
  ## Summary

  - frontend-toolkit MCP 서버 개발을 위한 에이전트 팀 + 스킬 체계 구성
  - revfactory/harness 플러그인 기반, 서브 에이전트 모드 + 파이프라인/전문가 풀 패턴
  - 이후 Phase(MCP 서버 구현, 테스트, 문서화)의 개발 워크플로우를 정의하는 인프라 레이어

  ## 배경

  - eng-review 결정(D6)에 따라 harness 사용
  - MCP 서버 개발은 도구 구현 / 코드 이식 / 테스트 / 리뷰 등 이질적 작업이 혼재
  - 에이전트별 전문 지식을 격리하고, 스킬로 워크플로우를 정의하여 일관된 품질 보장

  ## 산출물

  ### 에이전트 4개 (`.claude/agents/`)

  | 에이전트 | 역할 | 핵심 도메인 지식 |
  |---------|------|----------------|
  | mcp-builder | MCP 도구 구현 | Zod 스키마, server.tool() 패턴, 에러 코드 8개 |
  | integrator | 코드 복사 + 경로 적응 | frontend-mcp-kit → frontend-toolkit 매핑, 경로 적응 4규칙 |
  | tester | 테스트 작성 + 실행 | vitest 4.x 환경 (jsdom, globals, 모노레포 루트 config) |
  | reviewer | 구조 검증 + 코드 리뷰 | eng-review D1~D9 정합성, hooks/MCP 구조 검증 규칙 |

  ### 스킬 6개 (`.claude/skills/`)

  | 스킬 | 분류 | 용도 |
  |------|------|------|
  | create-mcp-tool | 개발 | MCP 도구 scaffold → 구현 → 등록 → 테스트 |
  | adapt-from-mcp-kit | 개발 | frontend-mcp-kit 코드 복사 + 경로 적응 |
  | test-mcp-tool | 개발 | 단위/통합 테스트 워크플로우 |
  | create-hook | 제품 (stub) | 훅 생성 파이프라인 — Phase 2에서 구현 |
  | use-hook | 제품 (stub) | 훅 탐색 + 사용법 안내 — Phase 2에서 구현 |
  | mcp-dev-orchestrator | 통합 | Phase 0~6 전체 파이프라인 조율 |

  ### 기타

  | 파일 | 내용 |
  |------|------|
  | `CLAUDE.md` | 하네스 포인터 (트리거 규칙 + 변경 이력) |
  | `docs/harness-architecture.md` | 의사결정 근거 + 동작 원리 문서 |

  ## 아키텍처 결정

  - **실행 모드:** 서브 에이전트 (에이전트 팀 아님) — 순차 의존이 강하고 실시간 통신 불필요
  - **패턴:** 파이프라인 + 전문가 풀 — scaffold → implement → test → review 순차 흐름 + 작업 유형별 전문가 선택
  - **구조적/AI 검증 분리 (D4):** reviewer = 구조적 검증(deterministic), create-hook 스킬 = AI 품질 검증

  ## eng-review 정합

  | 결정 | 반영 위치 |
  |------|----------|
  | D1 (소스 코드 복사) | integrator + adapt-from-mcp-kit |
  | D2 (cwd 모노레포 루트) | mcp-builder, tester |
  | D4 (구조적+AI 분리) | reviewer vs create-hook |
  | D5 (스킬→MCP 호출) | create-hook, use-hook |
  | D8 (복사+경로 적응) | integrator 매핑 테이블 |
  | D9 (도메인별 디렉토리) | mcp-dev-orchestrator Phase 1 |

  ## 다음 단계

  Phase 1(MCP 서버 구현)에서 이 하네스를 사용하여:
  1. `packages/mcp-server` 패키지 scaffold
  2. frontend-mcp-kit 코드 이식
  3. 훅/컴포넌트/테스트 도구 구현
  4. 단위 + 통합 테스트
  5. 구조 검증