### PR TITLE
feat: packages/mcp-server 패키지 생성

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,7 @@ export default tseslint.config(
   },
 
   {
-    files: ['**/*.test.ts', '**/*.test.tsx'],
+    files: ['**/*.test.ts', '**/*.test.tsx', '**/fixtures/**/*.ts', '**/fixtures/**/*.tsx'],
     extends: [tseslint.configs.disableTypeChecked],
   },
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@frontend-toolkit-js/mcp-server",
+  "version": "0.0.1",
+  "description": "MCP server for frontend-toolkit — test automation, hook/component analysis",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "frontend-toolkit-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "check-types": "tsc --noEmit"
+  },
+  "keywords": ["mcp", "testing", "frontend", "hooks", "components"],
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@typescript-eslint/typescript-estree": "^8.52.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.3"
+  }
+}

--- a/packages/mcp-server/src/__tests__/core/analyzer.test.ts
+++ b/packages/mcp-server/src/__tests__/core/analyzer.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { analyzeCode } from "../../analyzer.js";
+import { join } from "node:path";
+
+describe("analyzeCode", () => {
+  it("should return correct file metadata", async () => {
+    // 현재 프로젝트의 실제 파일 분석
+    const result = await analyzeCode(join(process.cwd(), "packages/mcp-server/src/analyzer.ts"));
+
+    expect(result.fileName).toBe("analyzer.ts");
+    expect(result.fileExtension).toBe("ts");
+  });
+
+  it("should extract named function exports", async () => {
+    const result = await analyzeCode(join(process.cwd(), "packages/mcp-server/src/analyzer.ts"));
+
+    const analyzeCodeExport = result.exports.find(
+      (e) => e.name === "analyzeCode"
+    );
+
+    expect(analyzeCodeExport).toBeDefined();
+    expect(analyzeCodeExport?.type).toBe("function");
+    expect(analyzeCodeExport?.params).toHaveLength(1);
+    expect(analyzeCodeExport?.params[0]?.name).toBe("filePath");
+  });
+
+  it("should extract import dependencies", async () => {
+    const result = await analyzeCode(join(process.cwd(), "packages/mcp-server/src/analyzer.ts"));
+
+    expect(result.dependencies).toContain("node:fs/promises");
+    expect(result.dependencies).toContain("node:path");
+    expect(result.dependencies).toContain(
+      "@typescript-eslint/typescript-estree"
+    );
+    expect(result.dependencies).toContain("./types.js");
+  });
+
+  it("should extract const/arrow function exports", async () => {
+    // schemas.ts는 export const 패턴 사용
+    const result = await analyzeCode(join(process.cwd(), "packages/mcp-server/src/schemas.ts"));
+
+    const schemaExport = result.exports.find(
+      (e) => e.name === "absolutePathSchema"
+    );
+
+    expect(schemaExport).toBeDefined();
+    expect(schemaExport?.type).toBe("const");
+  });
+
+  it("should throw error for non-existent file", async () => {
+    await expect(analyzeCode("/nonexistent/file.ts")).rejects.toThrow();
+  });
+
+  it("should handle multiple exports in single file", async () => {
+    // detector.ts는 여러 함수 export
+    const result = await analyzeCode(join(process.cwd(), "packages/mcp-server/src/detector.ts"));
+
+    const exportNames = result.exports.map((e) => e.name);
+
+    expect(exportNames).toContain("detectFramework");
+    expect(exportNames).toContain("detectTestEnvironment");
+    expect(result.exports.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/mcp-server/src/__tests__/core/component-analyzer.test.ts
+++ b/packages/mcp-server/src/__tests__/core/component-analyzer.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { analyzeComponent } from "../../component-analyzer.js";
+import { join } from "node:path";
+
+const fixturesPath = join(import.meta.dirname, "../fixtures");
+
+describe("analyzeComponent", () => {
+  describe("componentName extraction", () => {
+    it("should extract component name from named export function", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+
+      expect(result.componentName).toBe("SampleButton");
+    });
+
+    it("should extract component name from const export", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleInput.tsx")
+      );
+
+      expect(result.componentName).toBe("SampleInput");
+    });
+  });
+
+  describe("props extraction", () => {
+    it("should extract props from interface", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+
+      expect(result.props).toHaveLength(3);
+
+      const labelProp = result.props.find((p) => p.name === "label");
+      expect(labelProp).toEqual({
+        name: "label",
+        type: "string",
+        required: true,
+      });
+
+      const disabledProp = result.props.find((p) => p.name === "disabled");
+      expect(disabledProp?.required).toBe(false);
+    });
+
+    it("should extract props from type alias", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleInput.tsx")
+      );
+
+      expect(result.props.length).toBeGreaterThan(0);
+
+      const valueProp = result.props.find((p) => p.name === "value");
+      expect(valueProp).toBeDefined();
+    });
+  });
+
+  describe("hooks extraction", () => {
+    it("should extract built-in hooks", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+
+      const useState = result.hooks.find((h) => h.name === "useState");
+      const useCallback = result.hooks.find((h) => h.name === "useCallback");
+
+      expect(useState).toEqual({ name: "useState", isCustom: false });
+      expect(useCallback).toEqual({ name: "useCallback", isCustom: false });
+    });
+
+    it("should detect custom hooks", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleInput.tsx")
+      );
+
+      const customHook = result.hooks.find(
+        (h) => h.name === "useCustomValidation"
+      );
+
+      expect(customHook).toBeDefined();
+      expect(customHook?.isCustom).toBe(true);
+    });
+  });
+
+  describe("events extraction", () => {
+    it("should extract event handlers from JSX", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+
+      const eventNames = result.events.map((e) => e.name);
+
+      expect(eventNames).toContain("onClick");
+      expect(eventNames).toContain("onMouseEnter");
+      expect(eventNames).toContain("onMouseLeave");
+    });
+
+    it("should extract handler names", async () => {
+      const result = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+
+      const clickEvent = result.events.find((e) => e.name === "onClick");
+      expect(clickEvent?.handlerName).toBe("handleClick");
+    });
+  });
+
+  describe("component flags", () => {
+    it("should detect children usage", async () => {
+      const buttonResult = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+      const inputResult = await analyzeComponent(
+        join(fixturesPath, "SampleInput.tsx")
+      );
+
+      expect(buttonResult.hasChildren).toBe(false);
+      expect(inputResult.hasChildren).toBe(true);
+    });
+
+    it("should detect forwardRef usage", async () => {
+      const buttonResult = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+      const inputResult = await analyzeComponent(
+        join(fixturesPath, "SampleInput.tsx")
+      );
+
+      expect(buttonResult.isForwardRef).toBe(false);
+      expect(inputResult.isForwardRef).toBe(true);
+    });
+
+    it("should detect memo usage", async () => {
+      const buttonResult = await analyzeComponent(
+        join(fixturesPath, "SampleButton.tsx")
+      );
+      const inputResult = await analyzeComponent(
+        join(fixturesPath, "SampleInput.tsx")
+      );
+
+      expect(buttonResult.isMemo).toBe(false);
+      expect(inputResult.isMemo).toBe(true);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw error for non-existent file", async () => {
+      await expect(
+        analyzeComponent("/nonexistent/Component.tsx")
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/core/detector.test.ts
+++ b/packages/mcp-server/src/__tests__/core/detector.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { detectFramework, detectTestEnvironment } from "../../detector.js";
+
+describe("detectFramework", () => {
+  it("should detect vitest from package.json dependencies", async () => {
+    // 현재 프로젝트는 vitest를 devDependencies에 가지고 있음
+    const result = await detectFramework(".");
+    expect(result).toBe("vitest");
+  });
+
+  it("should return unknown for non-existent path", async () => {
+    const result = await detectFramework("/nonexistent/path");
+    expect(result).toBe("unknown");
+  });
+
+  it("should return unknown for path without package.json or config", async () => {
+    // /tmp는 package.json이나 테스트 설정 파일이 없음
+    const result = await detectFramework("/tmp");
+    expect(result).toBe("unknown");
+  });
+});
+
+describe("detectTestEnvironment", () => {
+  it("should return complete environment info", async () => {
+    const result = await detectTestEnvironment(".");
+
+    expect(result).toEqual({
+      framework: "vitest",
+      hasTestingLibrary: false,
+      testFilePattern: "*.test.ts",
+      configFile: "vitest.config.ts",
+    });
+  });
+
+  it("should detect vitest config file", async () => {
+    const result = await detectTestEnvironment(".");
+    expect(result.configFile).toBe("vitest.config.ts");
+  });
+
+  it("should return unknown framework for invalid path", async () => {
+    const result = await detectTestEnvironment("/nonexistent/path");
+
+    expect(result.framework).toBe("unknown");
+    expect(result.configFile).toBeNull();
+  });
+});

--- a/packages/mcp-server/src/__tests__/core/detector.test.ts
+++ b/packages/mcp-server/src/__tests__/core/detector.test.ts
@@ -26,8 +26,8 @@ describe("detectTestEnvironment", () => {
 
     expect(result).toEqual({
       framework: "vitest",
-      hasTestingLibrary: false,
-      testFilePattern: "*.test.ts",
+      hasTestingLibrary: true,
+      testFilePattern: "*.test.tsx",
       configFile: "vitest.config.ts",
     });
   });

--- a/packages/mcp-server/src/__tests__/core/schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/core/schemas.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { absolutePathSchema } from "../../schemas.js";
+
+describe("absolutePathSchema", () => {
+  it("should accept absolute path", () => {
+    const result = absolutePathSchema.safeParse("/Users/test/file.ts");
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = absolutePathSchema.safeParse("./src/file.ts");
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject path without leading slash", () => {
+    const result = absolutePathSchema.safeParse("src/file.ts");
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/__tests__/fixtures/SampleButton.tsx
+++ b/packages/mcp-server/src/__tests__/fixtures/SampleButton.tsx
@@ -1,0 +1,28 @@
+import React, { useState, useCallback } from "react";
+
+interface ButtonProps {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export function SampleButton({ label, disabled, onClick }: ButtonProps) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleClick = useCallback(() => {
+    if (!disabled) {
+      onClick();
+    }
+  }, [disabled, onClick]);
+
+  return (
+    <button
+      disabled={disabled}
+      onClick={handleClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {isHovered ? `${label}!` : label}
+    </button>
+  );
+}

--- a/packages/mcp-server/src/__tests__/fixtures/SampleInput.tsx
+++ b/packages/mcp-server/src/__tests__/fixtures/SampleInput.tsx
@@ -1,0 +1,29 @@
+import React, { forwardRef, memo } from "react";
+import { useCustomValidation } from "./hooks";
+
+type InputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  children?: React.ReactNode;
+};
+
+export const SampleInput = memo(
+  forwardRef<HTMLInputElement, InputProps>(function SampleInput(
+    { value, onChange, children },
+    ref
+  ) {
+    const { isValid } = useCustomValidation(value);
+
+    return (
+      <div>
+        <input
+          ref={ref}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        {!isValid && <span>Invalid</span>}
+        {children}
+      </div>
+    );
+  })
+);

--- a/packages/mcp-server/src/__tests__/fixtures/__fail_fixture.test.ts
+++ b/packages/mcp-server/src/__tests__/fixtures/__fail_fixture.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("fixture", () => {
+  it("의도적 실패", () => {
+    expect("hello").toBe("world");
+  });
+});

--- a/packages/mcp-server/src/__tests__/runners/vitest-runner.test.ts
+++ b/packages/mcp-server/src/__tests__/runners/vitest-runner.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import { runVitest } from "../../runners/vitest-runner.js";
+import { resolve } from "node:path";
+
+describe("runVitest", () => {
+  const projectRoot = process.cwd();
+  const defaultTimeout = 30;
+
+  describe("정상 실행", () => {
+    it("RunTestsOutput 형태를 반환한다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result).toHaveProperty("success");
+      expect(result).toHaveProperty("framework", "vitest");
+      expect(result).toHaveProperty("summary");
+      expect(result).toHaveProperty("results");
+    }, 30000);
+
+    it("올바른 summary 구조를 반환한다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.summary).toHaveProperty("total");
+      expect(result.summary).toHaveProperty("passed");
+      expect(result.summary).toHaveProperty("failed");
+      expect(result.summary).toHaveProperty("skipped");
+      expect(result.summary).toHaveProperty("duration");
+    }, 30000);
+
+    it("통과하는 테스트는 success: true를 반환한다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.success).toBe(true);
+      expect(result.summary.passed).toBeGreaterThan(0);
+      expect(result.summary.failed).toBe(0);
+    }, 30000);
+
+    it("개별 테스트 결과에 필수 필드가 포함된다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.results.length).toBeGreaterThan(0);
+
+      for (const testResult of result.results) {
+        expect(testResult).toHaveProperty("name");
+        expect(testResult).toHaveProperty("status");
+        expect(testResult).toHaveProperty("duration");
+        expect(testResult).toHaveProperty("location");
+        expect(["passed", "failed", "skipped"]).toContain(testResult.status);
+      }
+    }, 30000);
+
+    it("결과에 파일 경로가 포함된다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.results[0]?.location?.file).toContain("schemas.test.ts");
+    }, 30000);
+  });
+
+  describe("에러 처리", () => {
+    it("존재하지 않는 파일은 실패를 반환한다", async () => {
+      const testPath = resolve(projectRoot, "nonexistent.test.ts");
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.success).toBe(false);
+    }, 30000);
+
+    it("존재하지 않는 파일에서 framework 정보를 유지한다", async () => {
+      const testPath = resolve(projectRoot, "nonexistent.test.ts");
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.success).toBe(false);
+      expect(result.framework).toBe("vitest");
+    }, 30000);
+
+    it("에러 시 빈 결과를 반환한다", async () => {
+      const testPath = resolve(projectRoot, "nonexistent.test.ts");
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.results).toEqual([]);
+      expect(result.summary.total).toBe(0);
+    }, 30000);
+  });
+
+  describe("폴더 실행", () => {
+    it("폴더 내 모든 테스트를 실행한다", async () => {
+      const testPath = resolve(projectRoot, "packages/mcp-server/src/__tests__/core");
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.success).toBe(true);
+      expect(result.summary.total).toBeGreaterThan(5);
+    }, 60000);
+  });
+
+  describe("실패 테스트 처리", () => {
+    it("실패 테스트에서 location에 line과 column이 포함된다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/fixtures/__fail_fixture.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      expect(result.success).toBe(false);
+      const failed = result.results.find((r) => r.status === "failed");
+      expect(failed).toBeDefined();
+      expect(failed!.location?.line).toBeTypeOf("number");
+      expect(failed!.location?.column).toBeTypeOf("number");
+    }, 30000);
+
+    it("실패 테스트에서 error에 message, expected, actual이 포함된다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/fixtures/__fail_fixture.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      const failed = result.results.find((r) => r.status === "failed");
+      expect(failed!.error).toBeDefined();
+      expect(failed!.error!.message).toContain("expected");
+      expect(failed!.error!.expected).toBe("world");
+      expect(failed!.error!.actual).toBe("hello");
+    }, 30000);
+
+    it("실패 테스트에서 sourceContext가 포함된다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/fixtures/__fail_fixture.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      const failed = result.results.find((r) => r.status === "failed");
+      expect(failed!.sourceContext).toBeDefined();
+      expect(failed!.sourceContext).toContain(">");
+      expect(failed!.sourceContext).toContain("expect");
+    }, 30000);
+
+    it("실패 테스트에서 error.stack이 배열로 반환된다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/fixtures/__fail_fixture.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, defaultTimeout);
+
+      const failed = result.results.find((r) => r.status === "failed");
+      expect(Array.isArray(failed!.error!.stack)).toBe(true);
+    }, 30000);
+  });
+
+  describe("타임아웃", () => {
+    it("제한 시간 초과 시 프로세스를 종료하고 에러를 반환한다", async () => {
+      const testPath = resolve(projectRoot, "packages/mcp-server/src/__tests__/core");
+
+      // 0.001초(1ms)는 vitest 기동 시간보다 짧아서 반드시 타임아웃 발생
+      const result = await runVitest(testPath, projectRoot, 0.001);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("타임아웃");
+    }, 10000);
+
+    it("타임아웃 에러에 제한 시간이 포함된다", async () => {
+      const testPath = resolve(projectRoot, "packages/mcp-server/src/__tests__/core");
+
+      const result = await runVitest(testPath, projectRoot, 0.001);
+
+      expect(result.error).toContain("0.001초");
+    }, 10000);
+
+    it("타임아웃 시 framework 정보를 유지한다", async () => {
+      const testPath = resolve(projectRoot, "packages/mcp-server/src/__tests__/core");
+
+      const result = await runVitest(testPath, projectRoot, 0.001);
+
+      expect(result.framework).toBe("vitest");
+    }, 10000);
+
+    it("타임아웃 시 빈 결과와 요약을 반환한다", async () => {
+      const testPath = resolve(projectRoot, "packages/mcp-server/src/__tests__/core");
+
+      const result = await runVitest(testPath, projectRoot, 0.001);
+
+      expect(result.results).toEqual([]);
+      expect(result.summary.total).toBe(0);
+    }, 10000);
+
+    it("충분한 시간이면 정상 완료한다", async () => {
+      const testPath = resolve(
+        projectRoot,
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runVitest(testPath, projectRoot, 60);
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    }, 65000);
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/analyze-code.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/analyze-code.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { analyzeCodeSchema, runAnalyzeCode } from "../../tools/test/analyze-code.js";
+import { join } from "node:path";
+
+describe("analyzeCodeSchema", () => {
+  it("should accept absolute path", () => {
+    const result = analyzeCodeSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = analyzeCodeSchema.safeParse({
+      filePath: "./src/file.ts",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing filePath", () => {
+    const result = analyzeCodeSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runAnalyzeCode", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runAnalyzeCode({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+    expect(result.content[0]).toHaveProperty("text");
+  });
+
+  it("should return valid JSON in text content", async () => {
+    const result = await runAnalyzeCode({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("fileName");
+    expect(parsed).toHaveProperty("fileExtension");
+    expect(parsed).toHaveProperty("exports");
+    expect(parsed).toHaveProperty("dependencies");
+  });
+
+  it("should throw error for non-existent file", async () => {
+    await expect(
+      runAnalyzeCode({ filePath: "/nonexistent/file.ts" })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/analyze-component.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/analyze-component.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeComponentSchema,
+  runAnalyzeComponent,
+} from "../../tools/test/analyze-component.js";
+import { join } from "node:path";
+
+const fixturesPath = join(import.meta.dirname, "../fixtures");
+
+describe("analyzeComponentSchema", () => {
+  it("should accept absolute path", () => {
+    const result = analyzeComponentSchema.safeParse({
+      filePath: "/Users/test/Button.tsx",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = analyzeComponentSchema.safeParse({
+      filePath: "./components/Button.tsx",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runAnalyzeComponent", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runAnalyzeComponent({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+  });
+
+  it("should return component analysis in JSON", async () => {
+    const result = await runAnalyzeComponent({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("componentName");
+    expect(parsed).toHaveProperty("props");
+    expect(parsed).toHaveProperty("hooks");
+    expect(parsed).toHaveProperty("events");
+  });
+
+  it("should throw error for non-existent file", async () => {
+    await expect(
+      runAnalyzeComponent({ filePath: "/nonexistent/Component.tsx" })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/analyze-test-gaps.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/analyze-test-gaps.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeTestGapsSchema,
+  runAnalyzeTestGaps,
+} from "../../tools/test/analyze-test-gaps.js";
+import { join } from "node:path";
+
+describe("analyzeTestGapsSchema", () => {
+  it("should accept absolute path", () => {
+    const result = analyzeTestGapsSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = analyzeTestGapsSchema.safeParse({
+      filePath: "./src/file.ts",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runAnalyzeTestGaps", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runAnalyzeTestGaps({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+  });
+
+  it("should return gap analysis in JSON", async () => {
+    const result = await runAnalyzeTestGaps({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("sourceFile");
+    expect(parsed).toHaveProperty("testFile");
+    expect(parsed).toHaveProperty("tested");
+    expect(parsed).toHaveProperty("untested");
+  });
+
+  it("should return null when test file not in standard location", async () => {
+    // 테스트 파일이 __tests__/core/에 있어 표준 위치가 아님
+    const result = await runAnalyzeTestGaps({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    // findTestFile은 같은 폴더 또는 직접 하위 __tests__ 폴더만 검색
+    // src/__tests__/core/는 찾지 못함
+    expect(parsed.testFile).toBeNull();
+  });
+
+  it("should mark all exports as untested when no test file found", async () => {
+    const result = await runAnalyzeTestGaps({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    // 테스트 파일을 못 찾으면 모든 export가 untested
+    expect(parsed.untested).toContain("analyzeCode");
+    expect(parsed.tested).toHaveLength(0);
+  });
+
+  it("should return null testFile for untested module", async () => {
+    const result = await runAnalyzeTestGaps({
+      filePath: join(process.cwd(), "packages/mcp-server/src/types.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.testFile).toBeNull();
+  });
+
+  it("should throw error for non-existent file", async () => {
+    await expect(
+      runAnalyzeTestGaps({ filePath: "/nonexistent/file.ts" })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/detect-test-environment.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/detect-test-environment.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectTestEnvironmentSchema,
+  runDetectTestEnvironment,
+} from "../../tools/test/detect-test-environment.js";
+
+describe("detectTestEnvironmentSchema", () => {
+  it("should accept empty object (uses default)", () => {
+    const result = detectTestEnvironmentSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectPath).toBe(".");
+    }
+  });
+
+  it("should accept custom projectPath", () => {
+    const result = detectTestEnvironmentSchema.safeParse({
+      projectPath: "/custom/path",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectPath).toBe("/custom/path");
+    }
+  });
+});
+
+describe("runDetectTestEnvironment", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runDetectTestEnvironment({ projectPath: "." });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+  });
+
+  it("should return test environment info in JSON", async () => {
+    const result = await runDetectTestEnvironment({ projectPath: "." });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("framework");
+    expect(parsed).toHaveProperty("hasTestingLibrary");
+    expect(parsed).toHaveProperty("testFilePattern");
+    expect(parsed).toHaveProperty("configFile");
+  });
+
+  it("should detect vitest for current project", async () => {
+    const result = await runDetectTestEnvironment({ projectPath: "." });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.framework).toBe("vitest");
+  });
+
+  it("should return unknown for invalid path", async () => {
+    const result = await runDetectTestEnvironment({
+      projectPath: "/nonexistent/path",
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.framework).toBe("unknown");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/find-similar-tests.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/find-similar-tests.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  findSimilarTestsSchema,
+  runFindSimilarTests,
+} from "../../tools/test/find-similar-tests.js";
+import { join } from "node:path";
+
+describe("findSimilarTestsSchema", () => {
+  it("should accept absolute path with default maxResults", () => {
+    const result = findSimilarTestsSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxResults).toBe(5);
+    }
+  });
+
+  it("should accept custom maxResults", () => {
+    const result = findSimilarTestsSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+      maxResults: 10,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxResults).toBe(10);
+    }
+  });
+
+  it("should reject relative path", () => {
+    const result = findSimilarTestsSchema.safeParse({
+      filePath: "./src/file.ts",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runFindSimilarTests", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runFindSimilarTests({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      maxResults: 5,
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+  });
+
+  it("should return similar tests structure", async () => {
+    const result = await runFindSimilarTests({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      maxResults: 5,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("sourceFile");
+    expect(parsed).toHaveProperty("similarTests");
+    expect(parsed).toHaveProperty("totalFound");
+    expect(Array.isArray(parsed.similarTests)).toBe(true);
+  });
+
+  it("should respect maxResults limit", async () => {
+    const result = await runFindSimilarTests({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      maxResults: 2,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.similarTests.length).toBeLessThanOrEqual(2);
+  });
+
+  it("should find similar tests with low similarity for different folder", async () => {
+    const result = await runFindSimilarTests({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      maxResults: 10,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    // __tests__/core/ 폴더의 테스트는 다른 폴더이므로 low similarity로 포함
+    const analyzerTest = parsed.similarTests.find((t: { filePath: string }) =>
+      t.filePath.includes("analyzer.test.ts")
+    );
+
+    // 포함되어 있으면 similarity가 low
+    if (analyzerTest) {
+      expect(analyzerTest.similarity).toBe("low");
+    }
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/run-tests.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/run-tests.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { runTestsSchema, runTests } from "../../tools/test/run-tests.js";
+import { resolve } from "node:path";
+
+describe("runTestsSchema", () => {
+  describe("testPath validation", () => {
+    it("should require testPath", () => {
+      const result = runTestsSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it("should accept valid absolute testPath", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "/path/to/test.ts",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject relative testPath", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "./test.ts",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject testPath without leading slash", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "path/to/test.ts",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("projectPath validation", () => {
+    it("should accept optional projectPath", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "/path/to/test.ts",
+        projectPath: "/path/to/project",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.projectPath).toBe("/path/to/project");
+      }
+    });
+
+    it("should work without projectPath", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "/path/to/test.ts",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.projectPath).toBeUndefined();
+      }
+    });
+  });
+
+  describe("timeout 검증", () => {
+    it("미지정 시 기본값 30이 적용된다", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "/path/to/test.ts",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.timeout).toBe(30);
+      }
+    });
+
+    it("커스텀 값을 지정할 수 있다", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "/path/to/test.ts",
+        timeout: 60,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.timeout).toBe(60);
+      }
+    });
+
+    it("문자열은 거부한다", () => {
+      const result = runTestsSchema.safeParse({
+        testPath: "/path/to/test.ts",
+        timeout: "30",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("runTests", () => {
+  describe("response format", () => {
+    it("should return McpToolResponse format", async () => {
+      const result = await runTests({
+        testPath: "/nonexistent/path/test.ts",
+      });
+
+      expect(result).toHaveProperty("content");
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content[0]).toHaveProperty("type", "text");
+      expect(result.content[0]).toHaveProperty("text");
+    });
+
+    it("should return valid JSON in text field", async () => {
+      const result = await runTests({
+        testPath: "/nonexistent/path/test.ts",
+      });
+
+      expect(() => JSON.parse(result.content[0]!.text)).not.toThrow();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should return error when project root not found", async () => {
+      const result = await runTests({
+        testPath: "/nonexistent/path/test.ts",
+      });
+
+      const parsed = JSON.parse(result.content[0]!.text);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("프로젝트 루트");
+    });
+
+    it("should return error when framework unknown", async () => {
+      const result = await runTests({
+        testPath: "/tmp/test.ts",
+        projectPath: "/tmp",
+      });
+
+      const parsed = JSON.parse(result.content[0]!.text);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("테스트 프레임워크");
+    });
+  });
+
+  describe("vitest execution", () => {
+    it("should detect vitest framework", async () => {
+      const testPath = resolve(
+        process.cwd(),
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runTests({ testPath });
+      const parsed = JSON.parse(result.content[0]!.text);
+
+      expect(parsed.framework).toBe("vitest");
+    }, 30000);
+
+    it("should return success for passing tests", async () => {
+      const testPath = resolve(
+        process.cwd(),
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runTests({ testPath });
+      const parsed = JSON.parse(result.content[0]!.text);
+
+      expect(parsed.success).toBe(true);
+    }, 30000);
+
+    it("should return summary with test counts", async () => {
+      const testPath = resolve(
+        process.cwd(),
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runTests({ testPath });
+      const parsed = JSON.parse(result.content[0]!.text);
+
+      expect(parsed.summary).toHaveProperty("total");
+      expect(parsed.summary).toHaveProperty("passed");
+      expect(parsed.summary).toHaveProperty("failed");
+      expect(parsed.summary).toHaveProperty("skipped");
+      expect(parsed.summary).toHaveProperty("duration");
+      expect(parsed.summary.total).toBeGreaterThan(0);
+    }, 30000);
+
+    it("should return individual test results", async () => {
+      const testPath = resolve(
+        process.cwd(),
+        "packages/mcp-server/src/__tests__/fixtures/__fail_fixture.test.ts"
+      );
+
+      const result = await runTests({ testPath });
+      const parsed = JSON.parse(result.content[0]!.text);
+
+      expect(parsed.results.length).toBeGreaterThan(0);
+
+      const failedResult = parsed.results.find(
+        (r: { status: string }) => r.status === "failed"
+      );
+      expect(failedResult).toBeDefined();
+      expect(failedResult).toHaveProperty("name");
+      expect(failedResult).toHaveProperty("status", "failed");
+      expect(failedResult).toHaveProperty("duration");
+      expect(failedResult).toHaveProperty("location");
+      expect(failedResult.location).toHaveProperty("file");
+      expect(failedResult.location).toHaveProperty("line");
+    }, 30000);
+
+    it("should use provided projectPath", async () => {
+      const projectPath = process.cwd();
+      const testPath = resolve(
+        projectPath,
+        "packages/mcp-server/src/__tests__/core/schemas.test.ts"
+      );
+
+      const result = await runTests({ testPath, projectPath });
+      const parsed = JSON.parse(result.content[0]!.text);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.framework).toBe("vitest");
+    }, 30000);
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/scaffold-test.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/scaffold-test.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  scaffoldTestSchema,
+  runScaffoldTest,
+} from "../../tools/test/scaffold-test.js";
+import { join } from "node:path";
+
+describe("scaffoldTestSchema", () => {
+  it("should accept absolute path with default framework", () => {
+    const result = scaffoldTestSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.framework).toBe("auto");
+    }
+  });
+
+  it("should accept vitest framework", () => {
+    const result = scaffoldTestSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+      framework: "vitest",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.framework).toBe("vitest");
+    }
+  });
+
+  it("should accept jest framework", () => {
+    const result = scaffoldTestSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+      framework: "jest",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject invalid framework", () => {
+    const result = scaffoldTestSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+      framework: "mocha",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject relative path", () => {
+    const result = scaffoldTestSchema.safeParse({
+      filePath: "./src/file.ts",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runScaffoldTest", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runScaffoldTest({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      framework: "auto",
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+  });
+
+  it("should return scaffold info in JSON", async () => {
+    const result = await runScaffoldTest({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      framework: "auto",
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("testFilePath");
+    expect(parsed).toHaveProperty("framework");
+    expect(parsed).toHaveProperty("sourceFile");
+  });
+
+  it("should auto-detect vitest framework", async () => {
+    const result = await runScaffoldTest({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      framework: "auto",
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.framework).toBe("vitest");
+  });
+
+  it("should use specified framework when provided", async () => {
+    const result = await runScaffoldTest({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      framework: "jest",
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.framework).toBe("jest");
+  });
+
+  it("should include source file analysis", async () => {
+    const result = await runScaffoldTest({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+      framework: "auto",
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.sourceFile).toHaveProperty("fileName");
+    expect(parsed.sourceFile).toHaveProperty("exports");
+    expect(parsed.sourceFile).toHaveProperty("dependencies");
+  });
+
+  it("should throw error for non-existent file", async () => {
+    await expect(
+      runScaffoldTest({
+        filePath: "/nonexistent/file.ts",
+        framework: "auto",
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/suggest-a11y-tests.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/suggest-a11y-tests.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  suggestA11yTestsSchema,
+  runSuggestA11yTests,
+} from "../../tools/test/suggest-a11y-tests.js";
+import { join } from "node:path";
+
+const fixturesPath = join(import.meta.dirname, "../fixtures");
+
+describe("suggestA11yTestsSchema", () => {
+  it("should accept absolute path", () => {
+    const result = suggestA11yTestsSchema.safeParse({
+      filePath: "/Users/test/Button.tsx",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = suggestA11yTestsSchema.safeParse({
+      filePath: "./components/Button.tsx",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runSuggestA11yTests", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runSuggestA11yTests({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+  });
+
+  it("should return a11y analysis in JSON", async () => {
+    const result = await runSuggestA11yTests({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("hasIssues");
+    expect(parsed).toHaveProperty("suggestions");
+    expect(parsed).toHaveProperty("jestAxeExample");
+  });
+
+  it("should include jest-axe example code", async () => {
+    const result = await runSuggestA11yTests({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed.jestAxeExample).toContain("jest-axe");
+    expect(parsed.jestAxeExample).toContain("toHaveNoViolations");
+  });
+
+  it("should detect click without keyboard handler", async () => {
+    const result = await runSuggestA11yTests({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    // SampleButton has onClick without onKeyDown on button
+    const hasKeyboardSuggestion = parsed.suggestions.some(
+      (s: { type: string }) => s.type === "keyboard"
+    );
+    expect(hasKeyboardSuggestion).toBe(true);
+  });
+
+  it("should return error response for non-existent file", async () => {
+    const result = await runSuggestA11yTests({
+      filePath: "/nonexistent/Component.tsx",
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(parsed).toHaveProperty("error", true);
+    expect(parsed).toHaveProperty("message");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/suggest-test-names.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/suggest-test-names.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  suggestTestNamesSchema,
+  runSuggestTestNames,
+} from "../../tools/test/suggest-test-names.js";
+import { join } from "node:path";
+
+const fixturesPath = join(import.meta.dirname, "../fixtures");
+
+describe("suggestTestNamesSchema", () => {
+  it("should accept absolute path", () => {
+    const result = suggestTestNamesSchema.safeParse({
+      filePath: "/Users/test/file.ts",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = suggestTestNamesSchema.safeParse({
+      filePath: "./src/file.ts",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runSuggestTestNames", () => {
+  it("should return McpToolResponse format", async () => {
+    const result = await runSuggestTestNames({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]).toHaveProperty("type", "text");
+  });
+
+  it("should return array of test suggestions", async () => {
+    const result = await runSuggestTestNames({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+  });
+
+  it("should include describe and tests for each suggestion", async () => {
+    const result = await runSuggestTestNames({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    for (const suggestion of parsed) {
+      expect(suggestion).toHaveProperty("describe");
+      expect(suggestion).toHaveProperty("tests");
+      expect(Array.isArray(suggestion.tests)).toBe(true);
+    }
+  });
+
+  it("should generate component tests for tsx files", async () => {
+    const result = await runSuggestTestNames({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    const componentSuggestion = parsed.find(
+      (s: { describe: string }) => s.describe === "SampleButton"
+    );
+
+    expect(componentSuggestion).toBeDefined();
+    expect(componentSuggestion.tests).toContain("should render correctly");
+  });
+
+  it("should generate function tests for ts files", async () => {
+    const result = await runSuggestTestNames({
+      filePath: join(process.cwd(), "packages/mcp-server/src/analyzer.ts"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+
+    const functionSuggestion = parsed.find(
+      (s: { describe: string }) => s.describe === "analyzeCode"
+    );
+
+    expect(functionSuggestion).toBeDefined();
+    expect(functionSuggestion.tests).toContain("should return expected result");
+  });
+
+  it("should not duplicate describe names", async () => {
+    const result = await runSuggestTestNames({
+      filePath: join(fixturesPath, "SampleButton.tsx"),
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    const describeNames = parsed.map((s: { describe: string }) => s.describe);
+    const uniqueNames = [...new Set(describeNames)];
+
+    expect(describeNames.length).toBe(uniqueNames.length);
+  });
+
+  it("should throw error for non-existent file", async () => {
+    await expect(
+      runSuggestTestNames({ filePath: "/nonexistent/file.ts" })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/constants.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/constants.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { VITEST_CONFIGS, JEST_CONFIGS } from "../../utils/constants.js";
+
+describe("constants", () => {
+  describe("VITEST_CONFIGS", () => {
+    it("should be an array", () => {
+      expect(Array.isArray(VITEST_CONFIGS)).toBe(true);
+    });
+
+    it("should contain vitest.config.ts", () => {
+      expect(VITEST_CONFIGS).toContain("vitest.config.ts");
+    });
+
+    it("should contain vitest.config.js", () => {
+      expect(VITEST_CONFIGS).toContain("vitest.config.js");
+    });
+
+    it("should contain vitest.config.mts", () => {
+      expect(VITEST_CONFIGS).toContain("vitest.config.mts");
+    });
+
+    it("should have exactly 3 config options", () => {
+      expect(VITEST_CONFIGS.length).toBe(3);
+    });
+  });
+
+  describe("JEST_CONFIGS", () => {
+    it("should be an array", () => {
+      expect(Array.isArray(JEST_CONFIGS)).toBe(true);
+    });
+
+    it("should contain jest.config.js", () => {
+      expect(JEST_CONFIGS).toContain("jest.config.js");
+    });
+
+    it("should contain jest.config.ts", () => {
+      expect(JEST_CONFIGS).toContain("jest.config.ts");
+    });
+
+    it("should contain jest.config.json", () => {
+      expect(JEST_CONFIGS).toContain("jest.config.json");
+    });
+
+    it("should have exactly 3 config options", () => {
+      expect(JEST_CONFIGS.length).toBe(3);
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/detect-framework.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/detect-framework.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { detectFramework } from "../../utils/detect-framework.js";
+import { join } from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+describe("detectFramework", () => {
+  describe("with current project", () => {
+    it("should detect vitest for current project", async () => {
+      const result = await detectFramework(process.cwd());
+      expect(result).toBe("vitest");
+    });
+  });
+
+  describe("with config files", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "test-framework-"));
+      writeFileSync(join(tempDir, "package.json"), "{}");
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true });
+    });
+
+    it("should detect vitest from vitest.config.ts", async () => {
+      writeFileSync(join(tempDir, "vitest.config.ts"), "export default {}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("vitest");
+    });
+
+    it("should detect vitest from vitest.config.js", async () => {
+      writeFileSync(join(tempDir, "vitest.config.js"), "module.exports = {}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("vitest");
+    });
+
+    it("should detect vitest from vitest.config.mts", async () => {
+      writeFileSync(join(tempDir, "vitest.config.mts"), "export default {}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("vitest");
+    });
+
+    it("should detect jest from jest.config.js", async () => {
+      writeFileSync(join(tempDir, "jest.config.js"), "module.exports = {}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("jest");
+    });
+
+    it("should detect jest from jest.config.ts", async () => {
+      writeFileSync(join(tempDir, "jest.config.ts"), "export default {}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("jest");
+    });
+
+    it("should detect jest from jest.config.json", async () => {
+      writeFileSync(join(tempDir, "jest.config.json"), "{}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("jest");
+    });
+
+    it("should prioritize vitest over jest when both exist", async () => {
+      writeFileSync(join(tempDir, "vitest.config.ts"), "export default {}");
+      writeFileSync(join(tempDir, "jest.config.js"), "module.exports = {}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("vitest");
+    });
+  });
+
+  describe("with package.json dependencies", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "test-framework-"));
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true });
+    });
+
+    it("should detect vitest from dependencies", async () => {
+      writeFileSync(
+        join(tempDir, "package.json"),
+        JSON.stringify({ dependencies: { vitest: "^1.0.0" } })
+      );
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("vitest");
+    });
+
+    it("should detect vitest from devDependencies", async () => {
+      writeFileSync(
+        join(tempDir, "package.json"),
+        JSON.stringify({ devDependencies: { vitest: "^1.0.0" } })
+      );
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("vitest");
+    });
+
+    it("should detect jest from dependencies", async () => {
+      writeFileSync(
+        join(tempDir, "package.json"),
+        JSON.stringify({ dependencies: { jest: "^29.0.0" } })
+      );
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("jest");
+    });
+
+    it("should detect jest from devDependencies", async () => {
+      writeFileSync(
+        join(tempDir, "package.json"),
+        JSON.stringify({ devDependencies: { jest: "^29.0.0" } })
+      );
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("jest");
+    });
+
+    it("should prioritize vitest over jest in package.json", async () => {
+      writeFileSync(
+        join(tempDir, "package.json"),
+        JSON.stringify({
+          devDependencies: { vitest: "^1.0.0", jest: "^29.0.0" },
+        })
+      );
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("vitest");
+    });
+  });
+
+  describe("unknown framework", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "test-framework-"));
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true });
+    });
+
+    it("should return unknown when no framework detected", async () => {
+      writeFileSync(join(tempDir, "package.json"), "{}");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("unknown");
+    });
+
+    it("should return unknown when package.json is invalid", async () => {
+      writeFileSync(join(tempDir, "package.json"), "invalid json");
+
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("unknown");
+    });
+
+    it("should return unknown when no package.json exists", async () => {
+      const result = await detectFramework(tempDir);
+      expect(result).toBe("unknown");
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/find-project-root.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/find-project-root.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { findProjectRoot } from "../../utils/find-project-root.js";
+import { resolve, join } from "node:path";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+describe("findProjectRoot", () => {
+  describe("기존 모노레포에서", () => {
+    it("현재 디렉토리에서 모노레포 루트를 찾는다", () => {
+      const result = findProjectRoot(process.cwd());
+      expect(result).toBe(process.cwd());
+    });
+
+    it("하위 디렉토리에서 모노레포 루트를 찾는다", () => {
+      const subdir = resolve(process.cwd(), "packages/mcp-server/src");
+      const result = findProjectRoot(subdir);
+      expect(result).toBe(process.cwd());
+    });
+
+    it("깊은 하위 디렉토리에서 모노레포 루트를 찾는다", () => {
+      const deepDir = resolve(process.cwd(), "packages/mcp-server/src/__tests__/tools");
+      const result = findProjectRoot(deepDir);
+      expect(result).toBe(process.cwd());
+    });
+
+    it("파일 경로에서 모노레포 루트를 찾는다", () => {
+      const filePath = resolve(process.cwd(), "packages/mcp-server/src/index.ts");
+      const result = findProjectRoot(filePath);
+      expect(result).toBe(process.cwd());
+    });
+  });
+
+  describe("임시 디렉토리에서", () => {
+    it("pnpm-workspace.yaml이 있으면 루트를 찾는다", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "test-"));
+      writeFileSync(join(tempDir, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'");
+      mkdirSync(join(tempDir, "src"));
+
+      const result = findProjectRoot(join(tempDir, "src"));
+      expect(result).toBe(tempDir);
+
+      rmSync(tempDir, { recursive: true });
+    });
+
+    it("turbo.json이 있으면 루트를 찾는다", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "test-"));
+      writeFileSync(join(tempDir, "turbo.json"), "{}");
+      mkdirSync(join(tempDir, "src"));
+
+      const result = findProjectRoot(join(tempDir, "src"));
+      expect(result).toBe(tempDir);
+
+      rmSync(tempDir, { recursive: true });
+    });
+
+    it("모노레포 마커가 없으면 null을 반환한다", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "test-"));
+      mkdirSync(join(tempDir, "src"));
+
+      const result = findProjectRoot(join(tempDir, "src"));
+      expect(result).toBeNull();
+
+      rmSync(tempDir, { recursive: true });
+    });
+  });
+
+  describe("엣지 케이스", () => {
+    it("존재하지 않는 경로에서 null을 반환한다", () => {
+      const result = findProjectRoot("/nonexistent/path/that/does/not/exist");
+      expect(result).toBeNull();
+    });
+
+    it("마커 없는 루트 디렉토리에서 null을 반환한다", () => {
+      const result = findProjectRoot("/tmp");
+      expect(result).toBeNull();
+    });
+
+    it("존재하지 않는 파일 경로를 처리한다", () => {
+      const result = findProjectRoot(
+        resolve(process.cwd(), "nonexistent-file.ts")
+      );
+      expect(result).toBe(process.cwd());
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/format-results.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/format-results.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import { formatResults } from "../../utils/format-results.js";
+import type { RunTestsOutput } from "../../tools/test/run-tests.js";
+
+function createOutput(overrides: Partial<RunTestsOutput> = {}): RunTestsOutput {
+  return {
+    success: true,
+    framework: "vitest",
+    summary: {
+      total: 2,
+      passed: 2,
+      failed: 0,
+      skipped: 0,
+      duration: 100,
+    },
+    results: [
+      {
+        name: "테스트 1",
+        status: "passed",
+        duration: 50,
+        location: { file: "/src/test.ts", line: 10 },
+      },
+      {
+        name: "테스트 2",
+        status: "passed",
+        duration: 50,
+        location: { file: "/src/test.ts", line: 20 },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("formatResults", () => {
+  describe("전부 성공 시", () => {
+    it("results를 빈 배열로 반환한다", () => {
+      const output = createOutput();
+
+      const result = formatResults(output);
+
+      expect(result.results).toEqual([]);
+    });
+
+    it("summary는 그대로 유지한다", () => {
+      const output = createOutput();
+
+      const result = formatResults(output);
+
+      expect(result.summary).toEqual(output.summary);
+    });
+
+    it("success, framework 등 메타 정보를 유지한다", () => {
+      const output = createOutput();
+
+      const result = formatResults(output);
+
+      expect(result.success).toBe(true);
+      expect(result.framework).toBe("vitest");
+    });
+  });
+
+  describe("실패 있을 때", () => {
+    it("실패 테스트는 전체 정보를 유지한다", () => {
+      const output = createOutput({
+        success: false,
+        summary: {
+          total: 2,
+          passed: 1,
+          failed: 1,
+          skipped: 0,
+          duration: 100,
+        },
+        results: [
+          {
+            name: "성공 테스트",
+            status: "passed",
+            duration: 50,
+            location: { file: "/src/test.ts", line: 10 },
+          },
+          {
+            name: "실패 테스트",
+            status: "failed",
+            duration: 50,
+            error: {
+              message: "expected true to be false",
+              expected: "false",
+              actual: "true",
+              stack: ["    at /src/test.ts:20:5"],
+            },
+            location: { file: "/src/test.ts", line: 20, column: 5 },
+            sourceContext: ">   20 | expect(true).toBe(false)",
+          },
+        ],
+      });
+
+      const result = formatResults(output);
+
+      const failed = result.results.find((r) => r.status === "failed");
+      expect(failed).toBeDefined();
+      expect(failed!.error).toBeDefined();
+      expect(failed!.location).toBeDefined();
+      expect(failed!.sourceContext).toBeDefined();
+      expect(failed!.duration).toBe(50);
+    });
+
+    it("성공 테스트는 name과 status만 남긴다", () => {
+      const output = createOutput({
+        success: false,
+        summary: {
+          total: 2,
+          passed: 1,
+          failed: 1,
+          skipped: 0,
+          duration: 100,
+        },
+        results: [
+          {
+            name: "성공 테스트",
+            status: "passed",
+            duration: 50,
+            location: { file: "/src/test.ts", line: 10 },
+          },
+          {
+            name: "실패 테스트",
+            status: "failed",
+            duration: 50,
+            error: { message: "fail" },
+          },
+        ],
+      });
+
+      const result = formatResults(output);
+
+      const passed = result.results.find((r) => r.status === "passed");
+      expect(passed).toEqual({
+        name: "성공 테스트",
+        status: "passed",
+        duration: 0,
+      });
+    });
+
+    it("skipped 테스트도 축소한다", () => {
+      const output = createOutput({
+        success: false,
+        summary: {
+          total: 3,
+          passed: 1,
+          failed: 1,
+          skipped: 1,
+          duration: 100,
+        },
+        results: [
+          { name: "스킵", status: "skipped", duration: 0 },
+          { name: "성공", status: "passed", duration: 50 },
+          {
+            name: "실패",
+            status: "failed",
+            duration: 50,
+            error: { message: "fail" },
+          },
+        ],
+      });
+
+      const result = formatResults(output);
+
+      const skipped = result.results.find((r) => r.status === "skipped");
+      expect(skipped).toEqual({
+        name: "스킵",
+        status: "skipped",
+        duration: 0,
+      });
+    });
+  });
+
+  describe("엣지 케이스", () => {
+    it("results가 빈 배열이면 그대로 반환한다", () => {
+      const output = createOutput({
+        summary: {
+          total: 0,
+          passed: 0,
+          failed: 0,
+          skipped: 0,
+          duration: 0,
+        },
+        results: [],
+      });
+
+      const result = formatResults(output);
+
+      expect(result.results).toEqual([]);
+    });
+
+    it("원본 output을 변경하지 않는다", () => {
+      const output = createOutput();
+      const originalResults = [...output.results];
+
+      formatResults(output);
+
+      expect(output.results).toEqual(originalResults);
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/parse-error-message.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/parse-error-message.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { parseErrorMessage } from "../../utils/parse-error-message.js";
+
+describe("parseErrorMessage", () => {
+  describe("Expected/Received 패턴 파싱", () => {
+    it("쌍따옴표로 감싼 문자열을 추출한다", () => {
+      const message = `expect(received).toBe(expected)
+
+Expected: "hello"
+Received: "world"`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.message).toBe(message);
+      expect(result.expected).toBe("hello");
+      expect(result.actual).toBe("world");
+    });
+
+    it("홑따옴표로 감싼 문자열을 추출한다", () => {
+      const message = `Expected: 'foo'
+Received: 'bar'`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("foo");
+      expect(result.actual).toBe("bar");
+    });
+
+    it("따옴표 없는 숫자를 추출한다", () => {
+      const message = `Expected: 123
+Received: 456`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("123");
+      expect(result.actual).toBe("456");
+    });
+
+    it("따옴표 없는 boolean을 추출한다", () => {
+      const message = `Expected: true
+Received: false`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("true");
+      expect(result.actual).toBe("false");
+    });
+
+    it("대소문자 구분 없이 매칭한다", () => {
+      const message = `expected: "abc"
+received: "xyz"`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("abc");
+      expect(result.actual).toBe("xyz");
+    });
+  });
+
+  describe("패턴이 없는 경우", () => {
+    it("Expected/Received 패턴이 없으면 message만 반환한다", () => {
+      const message = "TypeError: Cannot read property 'foo' of undefined";
+
+      const result = parseErrorMessage(message);
+
+      expect(result.message).toBe(message);
+      expect(result.expected).toBeUndefined();
+      expect(result.actual).toBeUndefined();
+    });
+
+    it("빈 문자열이면 빈 message만 반환한다", () => {
+      const result = parseErrorMessage("");
+
+      expect(result.message).toBe("");
+      expect(result.expected).toBeUndefined();
+      expect(result.actual).toBeUndefined();
+    });
+  });
+
+  describe("부분 매칭", () => {
+    it("Expected만 있으면 expected만 추출한다", () => {
+      const message = `Expected: "hello"
+Some other error`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("hello");
+      expect(result.actual).toBeUndefined();
+    });
+
+    it("Received만 있으면 actual만 추출한다", () => {
+      const message = `Some error
+Received: "world"`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBeUndefined();
+      expect(result.actual).toBe("world");
+    });
+  });
+
+  describe("항상 원본 message를 포함한다", () => {
+    it("파싱 성공해도 원본 message를 유지한다", () => {
+      const message = `Expected: "a"
+Received: "b"`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.message).toBe(message);
+    });
+  });
+
+  describe("Jest 커스텀 레이블 패턴 파싱", () => {
+    it("Expected substring / Received string 추출한다", () => {
+      const message = `expect(received).toContain(expected) // indexOf
+
+Expected substring: "xyz"
+Received string:    "hello world"`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("xyz");
+      expect(result.actual).toBe("hello world");
+    });
+
+    it("Expected value / Received array 추출한다", () => {
+      const message = `expect(received).toContain(expected) // indexOf
+
+Expected value: 4
+Received array: [1,`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("4");
+      expect(result.actual).toBe("[1,");
+    });
+
+    it("Expected length / Received length 추출한다", () => {
+      const message = `expect(received).toHaveLength(expected)
+
+Expected length: 3
+Received length: 2`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("3");
+      expect(result.actual).toBe("2");
+    });
+
+    it("Expected pattern / Received string 추출한다", () => {
+      const message = `expect(received).toMatch(expected)
+
+Expected pattern: /xyz/
+Received string:  "hello world"`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.expected).toBe("/xyz/");
+      expect(result.actual).toBe("hello world");
+    });
+  });
+
+  describe("to <matcher> 패턴 파싱", () => {
+    it("expected 'X' to be 'Y' 패턴을 추출한다", () => {
+      const message = `AssertionError: expected 'hello' to be 'world' // Object.is equality`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.actual).toBe("hello");
+      expect(result.expected).toBe("world");
+    });
+
+    it("expected 'X' to deeply equal 'Y' 패턴을 추출한다", () => {
+      const message = `AssertionError: expected 'foo' to deeply equal 'bar'`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.actual).toBe("foo");
+      expect(result.expected).toBe("bar");
+    });
+
+    it("expected 'X' to contain 'Y' 패턴을 추출한다", () => {
+      const message = `AssertionError: expected 'hello world' to contain 'xyz'`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.actual).toBe("hello world");
+      expect(result.expected).toBe("xyz");
+    });
+  });
+
+  describe("따옴표 없는 값 파싱", () => {
+    it("숫자 비교를 추출한다", () => {
+      const message = `AssertionError: expected 123 to be 456 // Object.is equality`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.actual).toBe("123");
+      expect(result.expected).toBe("456");
+    });
+
+    it("객체 비교를 추출한다", () => {
+      const message = `AssertionError: expected { a: 1 } to deeply equal { a: 2 }`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.actual).toBe("{ a: 1 }");
+      expect(result.expected).toBe("{ a: 2 }");
+    });
+
+    it("boolean 비교를 추출한다", () => {
+      const message = `AssertionError: expected true to be false // Object.is equality`;
+
+      const result = parseErrorMessage(message);
+
+      expect(result.actual).toBe("true");
+      expect(result.expected).toBe("false");
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/parse-stack-trace.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/parse-stack-trace.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseStackTrace,
+  extractLocation,
+} from "../../utils/parse-stack-trace.js";
+
+describe("parseStackTrace", () => {
+  describe("스택 프레임 필터링", () => {
+    it("'at ' 으로 시작하는 라인만 추출한다", () => {
+      const message = `AssertionError: expected true to be false
+    at Object.<anonymous> (/src/test.ts:10:5)
+some random line
+    at run (/src/runner.ts:20:3)`;
+
+      const result = parseStackTrace(message);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain("/src/test.ts:10:5");
+      expect(result[1]).toContain("/src/runner.ts:20:3");
+    });
+
+    it("node_modules 경로를 제외한다", () => {
+      const message = `Error: fail
+    at Object.<anonymous> (/src/test.ts:10:5)
+    at Module._compile (node_modules/vitest/dist/index.js:1:1)
+    at run (/src/runner.ts:20:3)`;
+
+      const result = parseStackTrace(message);
+
+      expect(result).toHaveLength(2);
+      expect(result.some((l) => l.includes("node_modules"))).toBe(false);
+    });
+
+    it("node:internal 경로를 제외한다", () => {
+      const message = `Error: fail
+    at Object.<anonymous> (/src/test.ts:10:5)
+    at Module._compile (node:internal/modules/cjs/loader:1218:14)`;
+
+      const result = parseStackTrace(message);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("/src/test.ts");
+    });
+  });
+
+  describe("ANSI 이스케이프 코드 처리", () => {
+    it("ANSI 코드가 포함된 스택을 정상 파싱한다", () => {
+      const ESC = String.fromCharCode(27);
+      const message = `${ESC}[31mError${ESC}[0m
+    at Object.<anonymous> (${ESC}[1m/src/test.ts${ESC}[0m:10:5)`;
+
+      const result = parseStackTrace(message);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).not.toContain(String.fromCharCode(27));
+    });
+  });
+
+  describe("엣지 케이스", () => {
+    it("스택 트레이스가 없으면 빈 배열을 반환한다", () => {
+      const message = "TypeError: Cannot read property 'foo' of undefined";
+
+      const result = parseStackTrace(message);
+
+      expect(result).toEqual([]);
+    });
+
+    it("빈 문자열이면 빈 배열을 반환한다", () => {
+      expect(parseStackTrace("")).toEqual([]);
+    });
+
+    it("모든 프레임이 node_modules이면 빈 배열을 반환한다", () => {
+      const message = `Error
+    at Module._compile (node_modules/vitest/dist/index.js:1:1)
+    at node:internal/modules/cjs/loader:1218:14`;
+
+      const result = parseStackTrace(message);
+
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+describe("extractLocation", () => {
+  describe("라인/컬럼 추출", () => {
+    it("file:line:column 형식에서 line과 column을 추출한다", () => {
+      const stack = ["    at Object.<anonymous> (/src/test.ts:10:5)"];
+
+      const result = extractLocation(stack);
+
+      expect(result).toEqual({ line: 10, column: 5 });
+    });
+
+    it("file:line 형식에서 line만 추출한다", () => {
+      const stack = ["    at Object.<anonymous> (/src/test.ts:42)"];
+
+      const result = extractLocation(stack);
+
+      expect(result).toEqual({ line: 42 });
+    });
+
+    it("첫 번째 프레임만 사용한다", () => {
+      const stack = [
+        "    at first (/src/a.ts:10:5)",
+        "    at second (/src/b.ts:20:3)",
+      ];
+
+      const result = extractLocation(stack);
+
+      expect(result).toEqual({ line: 10, column: 5 });
+    });
+  });
+
+  describe("엣지 케이스", () => {
+    it("빈 배열이면 null을 반환한다", () => {
+      expect(extractLocation([])).toBeNull();
+    });
+
+    it("eval 프레임이면 null을 반환한다", () => {
+      const stack = ["    at eval (eval at <anonymous>, <anonymous>:1:1)"];
+
+      expect(extractLocation(stack)).toBeNull();
+    });
+
+    it("eval 프레임을 건너뛰고 다음 프레임에서 추출한다", () => {
+      const stack = [
+        "    at eval (eval at <anonymous>, <anonymous>:1:1)",
+        "    at Object.<anonymous> (/src/test.ts:15:5)",
+      ];
+
+      const result = extractLocation(stack);
+
+      expect(result).toEqual({ line: 15, column: 5 });
+    });
+
+    it("매칭되지 않는 형식이면 null을 반환한다", () => {
+      const stack = ["    at Object.<anonymous> (unknown)"];
+
+      expect(extractLocation(stack)).toBeNull();
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/read-source-context.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/read-source-context.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+import { readSourceContext } from "../../utils/read-source-context.js";
+import * as fs from "node:fs";
+
+vi.mock("node:fs");
+
+const SAMPLE_FILE = `import { describe } from "vitest";
+
+describe("sample", () => {
+  it("test 1", () => {
+    const x = 1;
+    expect(x).toBe(2);
+  });
+
+  it("test 2", () => {
+    expect(true).toBe(true);
+  });
+});
+`;
+
+describe("readSourceContext", () => {
+  describe("컨텍스트 읽기", () => {
+    it("실패 라인 기준 전후 3줄을 반환한다", () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+
+      const result = readSourceContext("/src/test.ts", 6);
+
+      expect(result).not.toBeNull();
+      const lines = result!.split("\n");
+      // line 6 기준 ±3 → line 3~9
+      expect(lines).toHaveLength(7);
+    });
+
+    it("실패 라인에 > 마커를 표시한다", () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+
+      const result = readSourceContext("/src/test.ts", 6);
+
+      const lines = result!.split("\n");
+      const failLine = lines.find((l) => l.startsWith(">"));
+      expect(failLine).toBeDefined();
+      expect(failLine).toContain("expect(x).toBe(2)");
+    });
+
+    it("다른 라인에는 공백 마커를 표시한다", () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+
+      const result = readSourceContext("/src/test.ts", 6);
+
+      const lines = result!.split("\n");
+      const nonFailLines = lines.filter((l) => l.startsWith(" "));
+      expect(nonFailLines.length).toBe(6);
+    });
+
+    it("라인 번호를 4자리로 패딩한다", () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+
+      const result = readSourceContext("/src/test.ts", 6);
+
+      expect(result).toMatch(/>\s+6 \|/);
+      expect(result).toMatch(/\s+3 \|/);
+    });
+  });
+
+  describe("파일 시작/끝 경계 처리", () => {
+    it("첫 번째 줄이 실패하면 시작 부분만 반환한다", () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+
+      const result = readSourceContext("/src/test.ts", 1);
+
+      const lines = result!.split("\n");
+      expect(lines[0]).toMatch(/^>/);
+      // line 1 기준: start=0, end=4 → 4줄
+      expect(lines).toHaveLength(4);
+    });
+
+    it("마지막 줄이 실패하면 끝 부분만 반환한다", () => {
+      const totalLines = SAMPLE_FILE.split("\n").length;
+      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+
+      const result = readSourceContext("/src/test.ts", totalLines);
+
+      const lines = result!.split("\n");
+      const markerLine = lines.find((l) => l.startsWith(">"));
+      expect(markerLine).toBeDefined();
+    });
+  });
+
+  describe("에러 처리", () => {
+    it("파일을 읽을 수 없으면 null을 반환한다", () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      const result = readSourceContext("/nonexistent/file.ts", 1);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/utils/read-source-context.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/read-source-context.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { readSourceContext } from "../../utils/read-source-context.js";
-import * as fs from "node:fs";
+import { readFileSync } from "node:fs";
 
-vi.mock("node:fs");
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+}));
 
 const SAMPLE_FILE = `import { describe } from "vitest";
 
@@ -19,9 +21,13 @@ describe("sample", () => {
 `;
 
 describe("readSourceContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe("컨텍스트 읽기", () => {
     it("실패 라인 기준 전후 3줄을 반환한다", () => {
-      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
 
       const result = readSourceContext("/src/test.ts", 6);
 
@@ -32,7 +38,7 @@ describe("readSourceContext", () => {
     });
 
     it("실패 라인에 > 마커를 표시한다", () => {
-      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
 
       const result = readSourceContext("/src/test.ts", 6);
 
@@ -43,7 +49,7 @@ describe("readSourceContext", () => {
     });
 
     it("다른 라인에는 공백 마커를 표시한다", () => {
-      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
 
       const result = readSourceContext("/src/test.ts", 6);
 
@@ -53,7 +59,7 @@ describe("readSourceContext", () => {
     });
 
     it("라인 번호를 4자리로 패딩한다", () => {
-      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
 
       const result = readSourceContext("/src/test.ts", 6);
 
@@ -64,7 +70,7 @@ describe("readSourceContext", () => {
 
   describe("파일 시작/끝 경계 처리", () => {
     it("첫 번째 줄이 실패하면 시작 부분만 반환한다", () => {
-      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
 
       const result = readSourceContext("/src/test.ts", 1);
 
@@ -76,7 +82,7 @@ describe("readSourceContext", () => {
 
     it("마지막 줄이 실패하면 끝 부분만 반환한다", () => {
       const totalLines = SAMPLE_FILE.split("\n").length;
-      vi.mocked(fs.readFileSync).mockReturnValue(SAMPLE_FILE);
+      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
 
       const result = readSourceContext("/src/test.ts", totalLines);
 
@@ -88,7 +94,7 @@ describe("readSourceContext", () => {
 
   describe("에러 처리", () => {
     it("파일을 읽을 수 없으면 null을 반환한다", () => {
-      vi.mocked(fs.readFileSync).mockImplementation(() => {
+      vi.mocked(readFileSync).mockImplementation(() => {
         throw new Error("ENOENT");
       });
 

--- a/packages/mcp-server/src/__tests__/utils/read-source-context.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/read-source-context.test.ts
@@ -1,35 +1,38 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
 import { readSourceContext } from "../../utils/read-source-context.js";
-import { readFileSync } from "node:fs";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-vi.mock("node:fs", () => ({
-  readFileSync: vi.fn(),
-}));
+const TEMP_DIR = join(tmpdir(), "read-source-context-test");
+const TEMP_FILE = join(TEMP_DIR, "sample.ts");
 
-const SAMPLE_FILE = `import { describe } from "vitest";
+const SAMPLE_CONTENT = [
+  'import { describe } from "vitest";',
+  "",
+  'describe("sample", () => {',
+  '  it("test 1", () => {',
+  "    const x = 1;",
+  "    expect(x).toBe(2);",
+  "  });",
+  "",
+  '  it("test 2", () => {',
+  "    expect(true).toBe(true);",
+  "  });",
+  "});",
+].join("\n");
 
-describe("sample", () => {
-  it("test 1", () => {
-    const x = 1;
-    expect(x).toBe(2);
-  });
+mkdirSync(TEMP_DIR, { recursive: true });
+writeFileSync(TEMP_FILE, SAMPLE_CONTENT);
 
-  it("test 2", () => {
-    expect(true).toBe(true);
-  });
+afterAll(() => {
+  rmSync(TEMP_DIR, { recursive: true, force: true });
 });
-`;
 
 describe("readSourceContext", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("컨텍스트 읽기", () => {
     it("실패 라인 기준 전후 3줄을 반환한다", () => {
-      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
-
-      const result = readSourceContext("/src/test.ts", 6);
+      const result = readSourceContext(TEMP_FILE, 6);
 
       expect(result).not.toBeNull();
       const lines = result!.split("\n");
@@ -38,9 +41,7 @@ describe("readSourceContext", () => {
     });
 
     it("실패 라인에 > 마커를 표시한다", () => {
-      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
-
-      const result = readSourceContext("/src/test.ts", 6);
+      const result = readSourceContext(TEMP_FILE, 6);
 
       const lines = result!.split("\n");
       const failLine = lines.find((l) => l.startsWith(">"));
@@ -49,9 +50,7 @@ describe("readSourceContext", () => {
     });
 
     it("다른 라인에는 공백 마커를 표시한다", () => {
-      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
-
-      const result = readSourceContext("/src/test.ts", 6);
+      const result = readSourceContext(TEMP_FILE, 6);
 
       const lines = result!.split("\n");
       const nonFailLines = lines.filter((l) => l.startsWith(" "));
@@ -59,9 +58,7 @@ describe("readSourceContext", () => {
     });
 
     it("라인 번호를 4자리로 패딩한다", () => {
-      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
-
-      const result = readSourceContext("/src/test.ts", 6);
+      const result = readSourceContext(TEMP_FILE, 6);
 
       expect(result).toMatch(/>\s+6 \|/);
       expect(result).toMatch(/\s+3 \|/);
@@ -70,9 +67,7 @@ describe("readSourceContext", () => {
 
   describe("파일 시작/끝 경계 처리", () => {
     it("첫 번째 줄이 실패하면 시작 부분만 반환한다", () => {
-      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
-
-      const result = readSourceContext("/src/test.ts", 1);
+      const result = readSourceContext(TEMP_FILE, 1);
 
       const lines = result!.split("\n");
       expect(lines[0]).toMatch(/^>/);
@@ -81,10 +76,9 @@ describe("readSourceContext", () => {
     });
 
     it("마지막 줄이 실패하면 끝 부분만 반환한다", () => {
-      const totalLines = SAMPLE_FILE.split("\n").length;
-      vi.mocked(readFileSync).mockReturnValue(SAMPLE_FILE);
+      const totalLines = SAMPLE_CONTENT.split("\n").length;
 
-      const result = readSourceContext("/src/test.ts", totalLines);
+      const result = readSourceContext(TEMP_FILE, totalLines);
 
       const lines = result!.split("\n");
       const markerLine = lines.find((l) => l.startsWith(">"));
@@ -94,10 +88,6 @@ describe("readSourceContext", () => {
 
   describe("에러 처리", () => {
     it("파일을 읽을 수 없으면 null을 반환한다", () => {
-      vi.mocked(readFileSync).mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
-
       const result = readSourceContext("/nonexistent/file.ts", 1);
 
       expect(result).toBeNull();

--- a/packages/mcp-server/src/analyzer.ts
+++ b/packages/mcp-server/src/analyzer.ts
@@ -1,0 +1,93 @@
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+import { parse, AST_NODE_TYPES } from "@typescript-eslint/typescript-estree";
+import type { CodeAnalysis, ExportInfo } from "./types.js";
+
+async function parseFile(filePath: string) {
+  const content = await readFile(filePath, "utf-8");
+  return parse(content, {
+    loc: true,
+    jsx: true,
+  });
+}
+
+function extractExports(ast: ReturnType<typeof parse>): ExportInfo[] {
+  const exports: ExportInfo[] = [];
+
+  for (const node of ast.body) {
+    // export function foo() {}
+    if (
+      node.type === AST_NODE_TYPES.ExportNamedDeclaration &&
+      node.declaration?.type === AST_NODE_TYPES.FunctionDeclaration
+    ) {
+      const func = node.declaration;
+      exports.push({
+        name: func.id?.name ?? "anonymous",
+        type: "function",
+        params: func.params.map((p) => ({
+          name: p.type === AST_NODE_TYPES.Identifier ? p.name : "param",
+          type: "unknown",
+        })),
+        returnType: "unknown",
+      });
+    }
+
+    // export const foo = () => {}
+    if (
+      node.type === AST_NODE_TYPES.ExportNamedDeclaration &&
+      node.declaration?.type === AST_NODE_TYPES.VariableDeclaration
+    ) {
+      for (const decl of node.declaration.declarations) {
+        if (decl.id.type === AST_NODE_TYPES.Identifier) {
+          const isArrowFunc = decl.init?.type === AST_NODE_TYPES.ArrowFunctionExpression;
+          exports.push({
+            name: decl.id.name,
+            type: isArrowFunc ? "function" : "const",
+            params: [],
+            returnType: "unknown",
+          });
+        }
+      }
+    }
+
+    // export default function
+    if (
+      node.type === AST_NODE_TYPES.ExportDefaultDeclaration &&
+      node.declaration.type === AST_NODE_TYPES.FunctionDeclaration
+    ) {
+      exports.push({
+        name: node.declaration.id?.name ?? "default",
+        type: "function",
+        params: [],
+        returnType: "unknown",
+      });
+    }
+  }
+
+  return exports;
+}
+
+function extractDependencies(ast: ReturnType<typeof parse>): string[] {
+  const deps: string[] = [];
+
+  for (const node of ast.body) {
+    if (node.type === AST_NODE_TYPES.ImportDeclaration) {
+      deps.push(String(node.source.value));
+    }
+  }
+
+  return deps;
+}
+
+export async function analyzeCode(filePath: string): Promise<CodeAnalysis> {
+  const ast = await parseFile(filePath);
+  const fileName = basename(filePath);
+  const fileExtension = extname(fileName).slice(1);
+
+  return {
+    fileName,
+    fileExtension,
+    exports: extractExports(ast),
+    dependencies: extractDependencies(ast),
+  };
+}

--- a/packages/mcp-server/src/component-analyzer.ts
+++ b/packages/mcp-server/src/component-analyzer.ts
@@ -1,0 +1,208 @@
+import { parse } from "@typescript-eslint/typescript-estree";
+import { readFile } from "node:fs/promises";
+import type { ComponentAnalysis, EventInfo, HookInfo, PropInfo } from "./types.js";
+import { basename } from "node:path";
+
+const REACT_BUILTIN_HOOKS = [
+  "useState",
+  "useEffect",
+  "useContext",
+  "useReducer",
+  "useCallback",
+  "useMemo",
+  "useRef",
+  "useImperativeHandle",
+  "useLayoutEffect",
+  "useDebugValue",
+  "useDeferredValue",
+  "useTransition",
+  "useId",
+  "useSyncExternalStore",
+  "useInsertionEffect",
+];
+
+async function parseFile(filePath: string) {
+  const content = await readFile(filePath, "utf-8");
+  return {
+    ast: parse(content, { loc: true, jsx: true }),
+    content,
+  };
+}
+
+// Props 추출 (TypeScript interface/type에서)
+function extractProps(content: string): PropInfo[] {
+  const props: PropInfo[] = [];
+
+  // interface Props { ... } 또는 type Props = { ... } 패턴 매칭
+  const propsPattern =
+    /(?:interface|type)\s+\w*Props\w*\s*(?:=\s*)?\{([^}]+)\}/g;
+  const match = propsPattern.exec(content);
+
+  if (match) {
+    const propsBlock = match[1] ?? "";
+    // 각 prop 라인 파싱: name?: type; 또는 name: type;
+    const propLines = propsBlock.split(/[;\n]/).filter((line) => line.trim());
+
+    for (const line of propLines) {
+      const propMatch = line.trim().match(/^(\w+)(\?)?:\s*(.+?)$/);
+      if (propMatch) {
+        props.push({
+          name: propMatch[1] ?? "",
+          type: (propMatch[3] ?? "").trim(),
+          required: !propMatch[2],
+        });
+      }
+    }
+  }
+
+  return props;
+}
+
+// Hooks 추출
+function extractHooks(ast: ReturnType<typeof parse>): HookInfo[] {
+  const hooks: HookInfo[] = [];
+  const seenHooks = new Set<string>();
+
+  function traverse(node: unknown) {
+    if (!node || typeof node !== "object") return;
+
+    const n = node as Record<string, unknown>;
+
+    // useXXX() 호출 찾기
+    if (
+      n.type === "CallExpression" &&
+      n.callee &&
+      (n.callee as Record<string, unknown>).type === "Identifier"
+    ) {
+      const callee = n.callee as Record<string, unknown>;
+      const name = callee.name as string;
+
+      if (name.startsWith("use") && !seenHooks.has(name)) {
+        seenHooks.add(name);
+        hooks.push({
+          name,
+          isCustom: !REACT_BUILTIN_HOOKS.includes(name),
+        });
+      }
+    }
+
+    // 재귀 탐색
+    for (const value of Object.values(n)) {
+      if (Array.isArray(value)) {
+        value.forEach(traverse);
+      } else if (value && typeof value === "object") {
+        traverse(value);
+      }
+    }
+  }
+
+  traverse(ast);
+  return hooks;
+}
+
+// Event Handlers 추출 (JSX에서 onXxx 속성 찾기)
+function extractEvents(ast: ReturnType<typeof parse>): EventInfo[] {
+  const events: EventInfo[] = [];
+  const seenEvents = new Set<string>();
+
+  function traverse(node: unknown) {
+    if (!node || typeof node !== "object") return;
+
+    const n = node as Record<string, unknown>;
+
+    // JSX 속성에서 onXxx 찾기
+    if (n.type === "JSXAttribute" && n.name) {
+      const attrName = n.name as Record<string, unknown>;
+      if (attrName.type === "JSXIdentifier") {
+        const name = attrName.name as string;
+
+        if (name.startsWith("on") && !seenEvents.has(name)) {
+          seenEvents.add(name);
+
+          // 핸들러 이름 추출
+          let handlerName = "handler";
+          if (
+            n.value &&
+            (n.value as Record<string, unknown>).type ===
+              "JSXExpressionContainer"
+          ) {
+            const expr = (n.value as Record<string, unknown>)
+              .expression as Record<string, unknown>;
+            if (expr && expr.type === "Identifier") {
+              handlerName = expr.name as string;
+            }
+          }
+
+          events.push({ name, handlerName });
+        }
+      }
+    }
+
+    // 재귀 탐색
+    for (const value of Object.values(n)) {
+      if (Array.isArray(value)) {
+        value.forEach(traverse);
+      } else if (value && typeof value === "object") {
+        traverse(value);
+      }
+    }
+  }
+
+  traverse(ast);
+  return events;
+}
+
+// 컴포넌트 이름 추출
+function extractComponentName(content: string, fileName: string): string {
+  // export default function ComponentName
+  const defaultFuncMatch = content.match(/export\s+default\s+function\s+(\w+)/);
+  if (defaultFuncMatch?.[1]) return defaultFuncMatch[1];
+
+  // export function ComponentName
+  const namedFuncMatch = content.match(/export\s+function\s+(\w+)/);
+  if (namedFuncMatch?.[1]) return namedFuncMatch[1];
+
+  // const ComponentName = () => 또는 const ComponentName: FC =
+  const constMatch = content.match(/(?:export\s+)?const\s+(\w+)\s*[=:]/);
+  if (constMatch?.[1]) return constMatch[1];
+
+  // 파일명에서 추출 (Button.tsx -> Button)
+  return fileName.replace(/\.(tsx|jsx|ts|js)$/, "");
+}
+
+// children prop 사용 여부
+function hasChildrenProp(content: string): boolean {
+  return (
+    content.includes("children") ||
+    content.includes("PropsWithChildren") ||
+    content.includes("{children}")
+  );
+}
+
+// forwardRef 사용 여부
+function isForwardRef(content: string): boolean {
+  return content.includes("forwardRef");
+}
+
+// memo 사용 여부
+function isMemo(content: string): boolean {
+  return content.includes("memo(") || content.includes("React.memo");
+}
+
+// 메인 분석 함수
+export async function analyzeComponent(
+  filePath: string
+): Promise<ComponentAnalysis> {
+  const { ast, content } = await parseFile(filePath);
+  const fileName = basename(filePath);
+
+  return {
+    componentName: extractComponentName(content, fileName),
+    props: extractProps(content),
+    hooks: extractHooks(ast),
+    events: extractEvents(ast),
+    hasChildren: hasChildrenProp(content),
+    isForwardRef: isForwardRef(content),
+    isMemo: isMemo(content),
+  };
+}

--- a/packages/mcp-server/src/detector.ts
+++ b/packages/mcp-server/src/detector.ts
@@ -1,0 +1,95 @@
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { TestFramework, TestEnvironment } from "./types.js";
+
+// 설정 파일 목록
+const VITEST_CONFIGS = [
+  "vitest.config.ts",
+  "vitest.config.js",
+  "vitest.config.mts",
+];
+
+const JEST_CONFIGS = ["jest.config.js", "jest.config.ts", "jest.config.json"];
+
+// package.json 읽기
+async function readPackageJson(
+  projectPath: string
+): Promise<Record<string, unknown> | null> {
+  try {
+    const content = await readFile(join(projectPath, "package.json"), "utf-8");
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+// 설정 파일 찾기
+function findConfigFile(projectPath: string, configs: string[]): string | null {
+  for (const config of configs) {
+    if (existsSync(join(projectPath, config))) {
+      return config;
+    }
+  }
+  return null;
+}
+
+// 프레임워크 감지
+export async function detectFramework(
+  projectPath: string
+): Promise<TestFramework> {
+  const pkg = await readPackageJson(projectPath);
+
+  if (pkg) {
+    const deps = {
+      ...(pkg.dependencies as Record<string, string>),
+      ...(pkg.devDependencies as Record<string, string>),
+    };
+
+    // 1순위: dependencies 확인
+    if (deps["vitest"]) return "vitest";
+    if (deps["jest"]) return "jest";
+  }
+
+  // 2순위: 설정 파일 확인
+  if (findConfigFile(projectPath, VITEST_CONFIGS)) return "vitest";
+  if (findConfigFile(projectPath, JEST_CONFIGS)) return "jest";
+
+  return "unknown";
+}
+
+// 테스트 환경 전체 감지
+export async function detectTestEnvironment(
+  projectPath: string
+): Promise<TestEnvironment> {
+  const pkg = await readPackageJson(projectPath);
+  const framework = await detectFramework(projectPath);
+
+  const deps = pkg
+    ? {
+        ...(pkg.dependencies as Record<string, string>),
+        ...(pkg.devDependencies as Record<string, string>),
+      }
+    : {};
+
+  // Testing Library 확인
+  const hasTestingLibrary = Boolean(deps["@testing-library/react"]);
+
+  // 설정 파일 찾기
+  const configFile =
+    framework === "vitest"
+      ? findConfigFile(projectPath, VITEST_CONFIGS)
+      : framework === "jest"
+        ? findConfigFile(projectPath, JEST_CONFIGS)
+        : null;
+
+  // 테스트 파일 패턴 (기본값)
+  const testFilePattern = hasTestingLibrary ? "*.test.tsx" : "*.test.ts";
+
+  return {
+    framework,
+    hasTestingLibrary,
+    testFilePattern,
+    configFile,
+  };
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  detectTestEnvironmentSchema,
+  runDetectTestEnvironment,
+} from "./tools/test/detect-test-environment.js";
+import { analyzeCodeSchema, runAnalyzeCode } from "./tools/test/analyze-code.js";
+import { runScaffoldTest, scaffoldTestSchema } from "./tools/test/scaffold-test.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  analyzeComponentSchema,
+  runAnalyzeComponent,
+} from "./tools/test/analyze-component.js";
+import {
+  findSimilarTestsSchema,
+  runFindSimilarTests,
+} from "./tools/test/find-similar-tests.js";
+import {
+  runSuggestA11yTests,
+  suggestA11yTestsSchema,
+} from "./tools/test/suggest-a11y-tests.js";
+import {
+  analyzeTestGapsSchema,
+  runAnalyzeTestGaps,
+} from "./tools/test/analyze-test-gaps.js";
+import {
+  runSuggestTestNames,
+  suggestTestNamesSchema,
+} from "./tools/test/suggest-test-names.js";
+import { runTests, runTestsSchema } from "./tools/test/run-tests.js";
+
+const server = new McpServer({
+  name: "frontend-toolkit",
+  version: "0.0.1",
+});
+
+// Tool 1: 테스트 환경 감지
+server.registerTool(
+  "detect_test_environment",
+  {
+    description: "프로젝트의 테스트 프레임워크와 환경을 감지합니다",
+    inputSchema: detectTestEnvironmentSchema,
+  },
+  runDetectTestEnvironment
+);
+
+// Tool 2: 코드 분석
+server.registerTool(
+  "analyze_code",
+  {
+    description:
+      "TypeScript/JavaScript 파일을 분석하여 exports와 dependencies를 추출합니다",
+    inputSchema: analyzeCodeSchema,
+  },
+  runAnalyzeCode
+);
+
+// Tool 3: 테스트 뼈대 정보 생성
+server.registerTool(
+  "scaffold_test",
+  {
+    description: "소스 파일 분석 후 테스트 작성에 필요한 정보를 제공합니다",
+    inputSchema: scaffoldTestSchema,
+  },
+  runScaffoldTest
+);
+
+// Tool 4: React 컴포넌트 분석
+server.registerTool(
+  "analyze_component",
+  {
+    description:
+      "React 컴포넌트를 분석하여 props, hooks, events 정보를 추출합니다",
+    inputSchema: analyzeComponentSchema,
+  },
+  runAnalyzeComponent
+);
+
+// Tool 5: 유사 테스트 검색
+server.registerTool(
+  "find_similar_tests",
+  {
+    description:
+      "프로젝트 내 유사한 테스트 파일을 검색하여 참고할 수 있도록 합니다",
+    inputSchema: findSimilarTestsSchema,
+  },
+  runFindSimilarTests
+);
+
+// Tool 6: 접근성 테스트 제안
+server.registerTool(
+  "suggest_a11y_tests",
+  {
+    description:
+      "React 컴포넌트의 접근성 테스트 포인트를 분석하고 jest-axe 사용법을 제안합니다",
+    inputSchema: suggestA11yTestsSchema,
+  },
+  runSuggestA11yTests
+);
+
+// Tool 7: 테스트 갭 분석
+server.registerTool(
+  "analyze_test_gaps",
+  {
+    description:
+      "소스 파일과 테스트 파일을 비교하여 테스트되지 않은 함수를 식별합니다",
+    inputSchema: analyzeTestGapsSchema,
+  },
+  runAnalyzeTestGaps
+);
+
+// Tool 8: 테스트 이름 제안
+server.registerTool(
+  "suggest_test_names",
+  {
+    description:
+      "소스 파일 분석 기반으로 describe/it 블록 구조와 테스트 이름을 제안합니다",
+    inputSchema: suggestTestNamesSchema,
+  },
+  runSuggestTestNames
+);
+
+// Tool 9: 테스트 실행
+server.registerTool(
+  "run_tests",
+  {
+    description: "테스트를 실행하고 결과를 반환합니다 (vitest/jest 지원)",
+    inputSchema: runTestsSchema,
+  },
+  runTests
+);
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("frontend-toolkit MCP server running");
+}
+
+main().catch(console.error);

--- a/packages/mcp-server/src/runners/index.ts
+++ b/packages/mcp-server/src/runners/index.ts
@@ -1,0 +1,2 @@
+export { runVitest } from "./vitest-runner.js";
+export { runJest } from "./jest-runner.js";

--- a/packages/mcp-server/src/runners/jest-runner.ts
+++ b/packages/mcp-server/src/runners/jest-runner.ts
@@ -1,0 +1,141 @@
+import { spawn } from "node:child_process";
+import type { RunTestsOutput, TestResult } from "../tools/test/run-tests.js";
+import { NPX_BIN } from "../utils/constants.js";
+import { parseErrorMessage } from "../utils/parse-error-message.js";
+import { extractLocation } from "../utils/parse-stack-trace.js";
+import { readSourceContext } from "../utils/read-source-context.js";
+
+interface JestAssertionResult {
+  title: string;
+  status: "passed" | "failed" | "pending" | "todo";
+  duration: number;
+  failureMessages?: string[];
+}
+
+interface JestTestResult {
+  name: string;
+  assertionResults: JestAssertionResult[];
+}
+
+interface JestJsonOutput {
+  numTotalTests: number;
+  numPassedTests: number;
+  numFailedTests: number;
+  numPendingTests: number;
+  success: boolean;
+  testResults: JestTestResult[];
+}
+
+export async function runJest(
+  testPath: string,
+  projectRoot: string,
+  timeout: number
+): Promise<RunTestsOutput> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (payload: RunTestsOutput) => {
+      if (settled) return;
+      settled = true;
+      resolve(payload);
+    };
+
+    const args = ["jest", "--json", testPath];
+    const child = spawn(NPX_BIN, args, {
+      cwd: projectRoot,
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish({
+        success: false,
+        framework: "jest",
+        summary: {
+          total: 0,
+          passed: 0,
+          failed: 0,
+          skipped: 0,
+          duration: timeout * 1000,
+        },
+        results: [],
+        error: `테스트 실행이 ${timeout}초 타임아웃을 초과했습니다. 테스트 환경(jsdom, happy-dom)이나 비동기 처리를 확인하세요.`,
+      });
+    }, timeout * 1000);
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", () => {
+      clearTimeout(timer);
+      try {
+        const json = JSON.parse(stdout) as JestJsonOutput;
+        const results: TestResult[] = [];
+
+        for (const testFile of json.testResults) {
+          for (const assertion of testFile.assertionResults) {
+            const error = assertion.failureMessages?.[0]
+              ? parseErrorMessage(assertion.failureMessages[0])
+              : undefined;
+
+            const loc = error?.stack ? extractLocation(error.stack) : null;
+
+            const sourceContext = loc?.line
+              ? (readSourceContext(testFile.name, loc.line) ?? undefined)
+              : undefined;
+
+            results.push({
+              name: assertion.title,
+              status:
+                assertion.status === "pending" || assertion.status === "todo"
+                  ? "skipped"
+                  : assertion.status,
+              duration: assertion.duration ?? 0,
+              location: { file: testFile.name, ...loc },
+              error,
+              sourceContext,
+            });
+          }
+        }
+
+        finish({
+          success: json.success,
+          framework: "jest",
+          summary: {
+            total: json.numTotalTests,
+            passed: json.numPassedTests,
+            failed: json.numFailedTests,
+            skipped: json.numPendingTests,
+            duration: results.reduce((sum, r) => sum + r.duration, 0),
+          },
+          results,
+        });
+      } catch {
+        finish({
+          success: false,
+          framework: "jest",
+          summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+          results: [],
+          error: stderr || "jest 실행 중 오류 발생",
+        });
+      }
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      finish({
+        success: false,
+        framework: "jest",
+        summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+        results: [],
+        error: error.message,
+      });
+    });
+  });
+}

--- a/packages/mcp-server/src/runners/vitest-runner.ts
+++ b/packages/mcp-server/src/runners/vitest-runner.ts
@@ -1,0 +1,156 @@
+import { spawn } from "node:child_process";
+import type { RunTestsOutput, TestResult } from "../tools/test/run-tests.js";
+import { NPX_BIN } from "../utils/constants.js";
+import { parseErrorMessage } from "../utils/parse-error-message.js";
+import { extractLocation } from "../utils/parse-stack-trace.js";
+import { readSourceContext } from "../utils/read-source-context.js";
+
+interface VitestAssertionResult {
+  title: string;
+  status: "passed" | "failed" | "pending";
+  duration: number;
+  failureMessages?: string[];
+  location?: { line: number; column: number };
+}
+
+interface VitestTestResult {
+  name: string;
+  assertionResults: VitestAssertionResult[];
+}
+
+interface VitestJsonOutput {
+  numTotalTests: number;
+  numPassedTests: number;
+  numFailedTests: number;
+  numPendingTests: number;
+  success: boolean;
+  testResults: VitestTestResult[];
+}
+
+export async function runVitest(
+  testPath: string,
+  projectRoot: string,
+  timeout: number
+): Promise<RunTestsOutput> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (payload: RunTestsOutput) => {
+      if (settled) return;
+      settled = true;
+      resolve(payload);
+    };
+
+    const args = ["vitest", "run", "--reporter=json", testPath];
+    const child = spawn(NPX_BIN, args, {
+      cwd: projectRoot,
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish({
+        success: false,
+        framework: "vitest",
+        summary: {
+          total: 0,
+          passed: 0,
+          failed: 0,
+          skipped: 0,
+          duration: timeout * 1000,
+        },
+        results: [],
+        error: `테스트 실행이 ${timeout}초 타임아웃을 초과했습니다. 테스트 환경(jsdom, happy-dom)이나 비동기 처리를 확인하세요.`,
+      });
+    }, timeout * 1000);
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    child.on("close", () => {
+      clearTimeout(timer);
+      try {
+        const json = JSON.parse(stdout) as VitestJsonOutput;
+        const results: TestResult[] = [];
+
+        for (const testFile of json.testResults) {
+          for (const assertion of testFile.assertionResults) {
+            const error = assertion.failureMessages?.[0]
+              ? parseErrorMessage(assertion.failureMessages[0])
+              : undefined;
+            const stackLoc = error?.stack ? extractLocation(error.stack) : null;
+            const loc = stackLoc ?? assertion.location;
+
+            const sourceContext = loc?.line
+              ? (readSourceContext(testFile.name, loc.line) ?? undefined)
+              : undefined;
+
+            results.push({
+              name: assertion.title,
+              status:
+                assertion.status === "pending" ? "skipped" : assertion.status,
+              duration: assertion.duration,
+              location: { file: testFile.name, ...loc },
+              error,
+              sourceContext,
+            });
+          }
+        }
+
+        // vitest 1.x 감지: 실패한 assertion에 location은 있지만
+        // failureMessages에 스택 트레이스가 없는 경우
+        const hasV1LocationIssue = json.testResults.some((tf) =>
+          tf.assertionResults.some(
+            (a) =>
+              a.status === "failed" &&
+              a.location != null &&
+              a.failureMessages?.[0] &&
+              !a.failureMessages[0].includes("\n    at ")
+          )
+        );
+
+        finish({
+          success: json.success,
+          framework: "vitest",
+          summary: {
+            total: json.numTotalTests,
+            passed: json.numPassedTests,
+            failed: json.numFailedTests,
+            skipped: json.numPendingTests,
+            duration: results.reduce((sum, r) => sum + r.duration, 0),
+          },
+          results,
+          ...(hasV1LocationIssue && {
+            warning:
+              "vitest 1.x에서는 외부 라이브러리(testing-library 등) 에러의 실패 위치가 부정확할 수 있습니다. vitest 2.0 이상으로 업그레이드를 권장합니다.",
+          }),
+        });
+      } catch {
+        finish({
+          success: false,
+          framework: "vitest",
+          summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+          results: [],
+          error: stderr || "vitest 실행 중 오류 발생",
+        });
+      }
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      finish({
+        success: false,
+        framework: "vitest",
+        summary: { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 },
+        results: [],
+        error: error.message,
+      });
+    });
+  });
+}

--- a/packages/mcp-server/src/schemas.ts
+++ b/packages/mcp-server/src/schemas.ts
@@ -1,0 +1,10 @@
+import { isAbsolute } from "node:path";
+import { z } from "zod";
+
+/**
+ * 절대 경로 검증 스키마
+ * 상대 경로 입력 시 명확한 에러 메시지 반환
+ */
+export const absolutePathSchema = z.string().refine((p) => isAbsolute(p), {
+  message: "절대 경로를 입력해주세요 (예: /Users/.../file.ts)",
+});

--- a/packages/mcp-server/src/tools/test/analyze-code.ts
+++ b/packages/mcp-server/src/tools/test/analyze-code.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { analyzeCode } from "../../analyzer.js";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+
+export const analyzeCodeSchema = z.object({
+  filePath: absolutePathSchema.describe("분석할 파일의 절대 경로"),
+});
+
+export type AnalyzeCodeInput = z.infer<typeof analyzeCodeSchema>;
+
+export async function runAnalyzeCode(
+  input: AnalyzeCodeInput
+): Promise<McpToolResponse> {
+  const { filePath } = input;
+
+  const result = await analyzeCode(filePath);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/test/analyze-component.ts
+++ b/packages/mcp-server/src/tools/test/analyze-component.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { analyzeComponent } from "../../component-analyzer.js";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+
+export const analyzeComponentSchema = z.object({
+  filePath: absolutePathSchema.describe(
+    "분석할 React 컴포넌트 파일의 절대 경로"
+  ),
+});
+
+export type AnalyzeComponentInput = z.infer<typeof analyzeComponentSchema>;
+
+export async function runAnalyzeComponent(
+  input: AnalyzeComponentInput
+): Promise<McpToolResponse> {
+  const { filePath } = input;
+
+  const result = await analyzeComponent(filePath);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/test/analyze-test-gaps.ts
+++ b/packages/mcp-server/src/tools/test/analyze-test-gaps.ts
@@ -1,0 +1,119 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { z } from "zod";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse, TestGapAnalysis } from "../../types.js";
+import { analyzeCode } from "../../analyzer.js";
+
+export const analyzeTestGapsSchema = z.object({
+  filePath: absolutePathSchema.describe("분석할 소스 파일의 절대 경로"),
+});
+
+export type AnalyzeTestGapsInput = z.infer<typeof analyzeTestGapsSchema>;
+
+// 테스트 파일 경로 찾기
+function findTestFile(sourceFile: string): string | null {
+  const dir = dirname(sourceFile);
+  const name = basename(sourceFile).replace(/\.(ts|tsx|js|jsx)$/, "");
+  const ext = basename(sourceFile).match(/\.(ts|tsx|js|jsx)$/)?.[0] ?? ".ts";
+
+  // 가능한 테스트 파일 경로들
+  const candidates = [
+    join(dir, `${name}.test${ext}`),
+    join(dir, `${name}.spec${ext}`),
+    join(dir, "__tests__", `${name}.test${ext}`),
+    join(dir, "__tests__", `${name}.spec${ext}`),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+// 테스트 파일에서 테스트된 함수명 추출
+async function extractTestedNames(testFilePath: string): Promise<string[]> {
+  const content = await readFile(testFilePath, "utf-8");
+  const testedNames: string[] = [];
+
+  // describe("FunctionName", ...) 패턴만 추출
+  // it/test 블록은 자연어 설명이므로 오탐 가능성이 높아 제외
+  const describeMatches = content.matchAll(/describe\s*\(\s*["']([^"']+)["']/g);
+  for (const match of describeMatches) {
+    const captured = match[1];
+    if (captured !== undefined) {
+      testedNames.push(captured);
+    }
+  }
+
+  return testedNames;
+}
+
+// 정규식 메타문자 이스케이프
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// 이름이 테스트되었는지 확인 (단어 경계 기반)
+function isNameTested(exportName: string, testedNames: string[]): boolean {
+  // 정규식 메타문자 이스케이프 후 단어 경계 패턴 생성
+  const escapedName = escapeRegExp(exportName);
+  const pattern = new RegExp(`\\b${escapedName}\\b`, "i");
+
+  return testedNames.some((tested) => pattern.test(tested));
+}
+
+async function analyzeGaps(filePath: string): Promise<TestGapAnalysis> {
+  const analysis = await analyzeCode(filePath);
+  const testFile = findTestFile(filePath);
+
+  const exportNames = analysis.exports.map((e) => e.name);
+
+  if (!testFile) {
+    return {
+      sourceFile: filePath,
+      testFile: null,
+      tested: [],
+      untested: exportNames,
+    };
+  }
+
+  const testedNames = await extractTestedNames(testFile);
+  const tested: string[] = [];
+  const untested: string[] = [];
+
+  for (const name of exportNames) {
+    if (isNameTested(name, testedNames)) {
+      tested.push(name);
+    } else {
+      untested.push(name);
+    }
+  }
+
+  return {
+    sourceFile: filePath,
+    testFile,
+    tested,
+    untested,
+  };
+}
+
+export async function runAnalyzeTestGaps(
+  input: AnalyzeTestGapsInput
+): Promise<McpToolResponse> {
+  const { filePath } = input;
+  const result = await analyzeGaps(filePath);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/test/detect-test-environment.ts
+++ b/packages/mcp-server/src/tools/test/detect-test-environment.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { detectTestEnvironment } from "../../detector.js";
+import type { McpToolResponse } from "../../types.js";
+
+// Tool 입력 스키마
+export const detectTestEnvironmentSchema = z.object({
+  projectPath: z
+    .string()
+    .optional()
+    .default(".")
+    .describe("프로젝트 경로 (기본값: 현재 디렉토리)"),
+});
+
+export type DetectTestEnvironmentInput = z.infer<
+  typeof detectTestEnvironmentSchema
+>;
+
+// Tool 실행 함수
+export async function runDetectTestEnvironment(
+  input: DetectTestEnvironmentInput
+): Promise<McpToolResponse> {
+  const { projectPath } = input;
+
+  const result = await detectTestEnvironment(projectPath);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/test/find-similar-tests.ts
+++ b/packages/mcp-server/src/tools/test/find-similar-tests.ts
@@ -1,0 +1,176 @@
+import { readdir, stat } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { z } from "zod";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse, SimilarTest } from "../../types.js";
+import { findProjectRoot } from "../../utils/find-project-root.js";
+
+export const findSimilarTestsSchema = z.object({
+  filePath: absolutePathSchema.describe(
+    "테스트를 작성할 소스 파일의 절대 경로"
+  ),
+  maxResults: z
+    .number()
+    .optional()
+    .default(5)
+    .describe("반환할 최대 결과 수 (기본값: 5)"),
+});
+
+export type FindSimilarTestsInput = z.infer<typeof findSimilarTestsSchema>;
+
+// 테스트 파일인지 확인
+function isTestFile(fileName: string): boolean {
+  return /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(fileName);
+}
+
+// 재귀적으로 테스트 파일 검색
+async function findTestFiles(
+  dir: string,
+  files: string[] = []
+): Promise<string[]> {
+  try {
+    const entries = await readdir(dir);
+
+    for (const entry of entries) {
+      if (entry === "node_modules" || entry === "dist" || entry === ".git") {
+        continue;
+      }
+
+      const fullPath = join(dir, entry);
+      const stats = await stat(fullPath);
+
+      if (stats.isDirectory()) {
+        await findTestFiles(fullPath, files);
+      } else if (isTestFile(entry)) {
+        files.push(fullPath);
+      }
+    }
+  } catch {
+    // 권한 오류 등 무시
+  }
+
+  return files;
+}
+
+// 유사도 계산
+function calculateSimilarity(
+  sourceFile: string,
+  testFile: string
+): SimilarTest | null {
+  const sourceName = basename(sourceFile).replace(/\.(ts|tsx|js|jsx)$/, "");
+  const sourceDir = dirname(sourceFile);
+  const testName = basename(testFile).replace(
+    /\.(test|spec)\.(ts|tsx|js|jsx)$/,
+    ""
+  );
+  const testDir = dirname(testFile);
+
+  // 같은 파일의 테스트 제외
+  if (sourceName === testName) {
+    // 같은 폴더의 테스트 (Button.tsx -> Button.test.tsx)
+    if (sourceDir === testDir) {
+      return null;
+    }
+    // __tests__ 폴더 내 테스트 (Button.tsx -> __tests__/Button.test.tsx)
+    if (basename(testDir) === "__tests__" && dirname(testDir) === sourceDir) {
+      return null;
+    }
+  }
+
+  // 같은 폴더 + 이름에 공통 단어 포함 (Button, IconButton)
+  if (sourceDir === testDir) {
+    if (
+      testName.includes(sourceName) ||
+      sourceName.includes(testName) ||
+      hasCommonWord(sourceName, testName)
+    ) {
+      return {
+        filePath: testFile,
+        similarity: "high",
+        reason: `같은 폴더의 유사한 컴포넌트 (${testName})`,
+      };
+    }
+    return {
+      filePath: testFile,
+      similarity: "medium",
+      reason: "같은 폴더의 테스트 파일",
+    };
+  }
+
+  // 같은 상위 폴더 (components/buttons vs components/inputs)
+  const sourceParent = dirname(sourceDir);
+  const testParent = dirname(testDir);
+  if (sourceParent === testParent) {
+    return {
+      filePath: testFile,
+      similarity: "medium",
+      reason: "인접 폴더의 테스트 파일",
+    };
+  }
+
+  // 이름 유사성만 있는 경우
+  if (
+    testName.includes(sourceName) ||
+    sourceName.includes(testName) ||
+    hasCommonWord(sourceName, testName)
+  ) {
+    return {
+      filePath: testFile,
+      similarity: "low",
+      reason: `유사한 이름의 컴포넌트 (${testName})`,
+    };
+  }
+
+  return null;
+}
+
+// 공통 단어 확인 (Button, SubmitButton -> "Button" 공통)
+function hasCommonWord(name1: string, name2: string): boolean {
+  const words1 = splitCamelCase(name1);
+  const words2 = splitCamelCase(name2);
+  return words1.some((w) => words2.includes(w) && w.length > 2);
+}
+
+// CamelCase 분리 (IconButton -> ["Icon", "Button"])
+function splitCamelCase(str: string): string[] {
+  return str.split(/(?=[A-Z])/).filter((s) => s.length > 0);
+}
+
+export async function runFindSimilarTests(
+  input: FindSimilarTestsInput
+): Promise<McpToolResponse> {
+  const { filePath, maxResults } = input;
+
+  const projectRoot = findProjectRoot(filePath) ?? dirname(filePath);
+  const allTestFiles = await findTestFiles(projectRoot);
+
+  const similarTests: SimilarTest[] = [];
+
+  for (const testFile of allTestFiles) {
+    const similarity = calculateSimilarity(filePath, testFile);
+    if (similarity) {
+      similarTests.push(similarity);
+    }
+  }
+
+  // 유사도 순 정렬 (high > medium > low)
+  const priorityOrder = { high: 0, medium: 1, low: 2 };
+  similarTests.sort(
+    (a, b) => priorityOrder[a.similarity] - priorityOrder[b.similarity]
+  );
+
+  const result = {
+    sourceFile: filePath,
+    similarTests: similarTests.slice(0, maxResults),
+    totalFound: similarTests.length,
+  };
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/test/run-tests.ts
+++ b/packages/mcp-server/src/tools/test/run-tests.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+import { absolutePathSchema } from "../../schemas.js";
+import {
+  findProjectRoot,
+  detectFramework,
+  formatResults,
+} from "../../utils/index.js";
+import type { McpToolResponse } from "../../types.js";
+import { runVitest, runJest } from "../../runners/index.js";
+
+export const runTestsSchema = z.object({
+  testPath: absolutePathSchema.describe(
+    "실행할 테스트 파일 또는 폴더의 절대 경로"
+  ),
+  projectPath: z
+    .string()
+    .optional()
+    .describe("프로젝트 루트 경로 (미지정 시 자동 탐색)"),
+
+  timeout: z
+    .number()
+    .optional()
+    .default(30)
+    .describe("테스트 실행 제한 시간 (초, 기본값: 30"),
+});
+
+export type RunTestsInput = z.infer<typeof runTestsSchema>;
+
+export interface TestErrorInfo {
+  message: string;
+  expected?: string;
+  actual?: string;
+  stack?: string[];
+}
+
+export interface TestLocation {
+  file: string;
+  line?: number;
+  column?: number;
+}
+
+export interface TestResult {
+  name: string;
+  status: "passed" | "failed" | "skipped";
+  duration: number;
+  error?: TestErrorInfo;
+  location?: TestLocation;
+  sourceContext?: string;
+}
+
+export interface RunTestsOutput {
+  success: boolean;
+  framework: "vitest" | "jest" | "unknown";
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    duration: number;
+  };
+  results: TestResult[];
+  error?: string;
+  warning?: string;
+}
+
+export async function runTests(input: RunTestsInput): Promise<McpToolResponse> {
+  const { testPath, projectPath, timeout = 30 } = input;
+
+  const root = projectPath ?? findProjectRoot(testPath);
+  if (!root) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            success: false,
+            error: "프로젝트 루트를 찾을 수 없습니다",
+          }),
+        },
+      ],
+    };
+  }
+
+  const framework = await detectFramework(root);
+  if (framework === "unknown") {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            success: false,
+            error: "테스트 프레임워크를 감지할 수 없습니다 (vitest/jest)",
+          }),
+        },
+      ],
+    };
+  }
+
+  let result: RunTestsOutput;
+
+  if (framework === "vitest") {
+    result = await runVitest(testPath, root, timeout);
+  } else {
+    result = await runJest(testPath, root, timeout);
+  }
+
+  result = formatResults(result);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/test/scaffold-test.ts
+++ b/packages/mcp-server/src/tools/test/scaffold-test.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { dirname } from "node:path";
+import { detectTestEnvironment } from "../../detector.js";
+import { analyzeCode } from "../../analyzer.js";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { findProjectRoot } from "../../utils/find-project-root.js";
+
+export const scaffoldTestSchema = z.object({
+  filePath: absolutePathSchema.describe(
+    "테스트를 생성할 소스 파일의 절대 경로"
+  ),
+  framework: z
+    .enum(["vitest", "jest", "auto"])
+    .optional()
+    .default("auto")
+    .describe("테스트 프레임워크 (기본값: auto)"),
+});
+
+export type ScaffoldTestInput = z.infer<typeof scaffoldTestSchema>;
+
+export async function runScaffoldTest(
+  input: ScaffoldTestInput
+): Promise<McpToolResponse> {
+  const { filePath, framework } = input;
+
+  // 프레임워크 감지
+  let targetFramework: string = framework;
+  if (framework === "auto") {
+    const projectPath = findProjectRoot(filePath) ?? dirname(filePath);
+    const env = await detectTestEnvironment(projectPath);
+    targetFramework = env.framework; // unknown이면 그대로 반환 (AI가 판단)
+  }
+
+  // 코드 분석
+  const analysis = await analyzeCode(filePath);
+
+  // 테스트 파일 경로 생성
+  const testFilePath = filePath.replace(/\.(ts|tsx|js|jsx)$/, ".test.$1");
+
+  // AI에게 전달할 정보만 반환
+  const result = {
+    testFilePath,
+    framework: targetFramework,
+    sourceFile: {
+      fileName: analysis.fileName,
+      fileExtension: analysis.fileExtension,
+      exports: analysis.exports,
+      dependencies: analysis.dependencies,
+    },
+  };
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/test/suggest-a11y-tests.ts
+++ b/packages/mcp-server/src/tools/test/suggest-a11y-tests.ts
@@ -1,0 +1,175 @@
+import { z } from "zod";
+import { readFile } from "node:fs/promises";
+import { absolutePathSchema } from "../../schemas.js";
+import type { A11yAnalysis, A11ySuggestion, McpToolResponse } from "../../types.js";
+
+export const suggestA11yTestsSchema = z.object({
+  filePath: absolutePathSchema.describe(
+    "분석할 React 컴포넌트 파일의 절대 경로"
+  ),
+});
+
+export type SuggestA11yTestsInput = z.infer<typeof suggestA11yTestsSchema>;
+
+// JSX 시작 태그 추출 (중괄호 깊이 추적하여 정확한 태그 경계 파악)
+function extractJsxOpenTags(content: string): string[] {
+  const tags: string[] = [];
+  let i = 0;
+
+  while (i < content.length) {
+    // 시작 태그 찾기 (<로 시작하고 </가 아닌 것)
+    if (content[i] === "<" && content[i + 1] !== "/") {
+      let depth = 0;
+      let j = i + 1;
+
+      while (j < content.length) {
+        if (content[j] === "{") depth++;
+        else if (content[j] === "}") depth--;
+        else if (content[j] === ">" && depth === 0) {
+          tags.push(content.slice(i, j + 1));
+          break;
+        }
+        j++;
+      }
+      i = j + 1;
+    } else {
+      i++;
+    }
+  }
+
+  return tags;
+}
+
+// onClick이 있지만 키보드 핸들러가 없는 태그 검사
+function checkClickWithoutKeyboard(content: string): boolean {
+  const tags = extractJsxOpenTags(content);
+
+  for (const tag of tags) {
+    const hasOnClick = /onClick/.test(tag);
+    const hasKeyboardHandler = /onKeyDown|onKeyPress|onKeyUp/.test(tag);
+
+    if (hasOnClick && !hasKeyboardHandler) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// 접근성 검사 규칙 (정규식 기반)
+const A11Y_RULES = {
+  // img 태그에 alt 속성 필요
+  imgWithoutAlt: {
+    pattern: /<img(?![^>]*alt=)[^>]*>/g,
+    type: "aria" as const,
+    element: "img",
+    suggestion: "img 태그에 alt 속성 추가 필요",
+  },
+  // button에 텍스트 또는 aria-label 필요
+  // aria-label/aria-labelledby가 없고 내용이 비어있는 버튼만 매칭
+  buttonWithoutLabel: {
+    pattern:
+      /<button(?![^>]*aria-label(?:ledby)?=)[^>]*>[\s]*<\/button>|<button(?![^>]*aria-label(?:ledby)?=)[^>]*\/>/g,
+    type: "aria" as const,
+    element: "button",
+    suggestion: "빈 button에 aria-label 또는 텍스트 콘텐츠 추가 필요",
+  },
+  // div/span에 onClick이 있지만 role/tabIndex가 없는 경우
+  // role 또는 tabIndex가 이미 있으면 제외
+  divClickable: {
+    pattern: /<(?:div|span)(?![^>]*(?:role=|tabIndex=))[^>]*onClick[^>]*>/g,
+    type: "aria" as const,
+    element: "div/span",
+    suggestion: "클릭 가능한 div/span에 role='button'과 tabIndex={0} 추가 필요",
+  },
+  // input에 label 연결 필요
+  // aria-label, aria-labelledby, id가 모두 없는 input만 매칭
+  inputWithoutLabel: {
+    pattern: /<input(?![^>]*(?:aria-label(?:ledby)?=|id=))[^>]*>/g,
+    type: "aria" as const,
+    element: "input",
+    suggestion: "input에 aria-label 또는 연결된 label 추가 필요",
+  },
+};
+
+// jest-axe 예시 코드
+const JEST_AXE_EXAMPLE = `import { axe, toHaveNoViolations } from 'jest-axe';
+
+ expect.extend(toHaveNoViolations);
+
+ it('should have no accessibility violations', async () => {
+   const { container } = render(<Component />);
+   const results = await axe(container);
+   expect(results).toHaveNoViolations();
+ });`;
+
+async function analyzeA11y(filePath: string): Promise<A11yAnalysis> {
+  const content = await readFile(filePath, "utf-8");
+  const suggestions: A11ySuggestion[] = [];
+
+  // 1. clickWithoutKeyboard 검사 (별도 함수로 처리)
+  if (checkClickWithoutKeyboard(content)) {
+    suggestions.push({
+      type: "keyboard",
+      suggestion:
+        "onClick이 있는 요소에 키보드 이벤트 핸들러(onKeyDown) 추가 필요",
+    });
+  }
+
+  // 2. 나머지 규칙 검사 (정규식 기반)
+  for (const [, rule] of Object.entries(A11Y_RULES)) {
+    const matches = content.match(rule.pattern);
+    if (matches && matches.length > 0) {
+      suggestions.push({
+        type: rule.type,
+        element: "element" in rule ? rule.element : undefined,
+        suggestion: rule.suggestion,
+      });
+    }
+  }
+
+  return {
+    hasIssues: suggestions.length > 0,
+    suggestions,
+    jestAxeExample: JEST_AXE_EXAMPLE,
+  };
+}
+
+export async function runSuggestA11yTests(
+  input: SuggestA11yTestsInput
+): Promise<McpToolResponse> {
+  const { filePath } = input;
+
+  try {
+    const result = await analyzeA11y(filePath);
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "알 수 없는 오류";
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              error: true,
+              filePath,
+              message: `파일 분석 실패: ${errorMessage}`,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  }
+}

--- a/packages/mcp-server/src/tools/test/suggest-test-names.ts
+++ b/packages/mcp-server/src/tools/test/suggest-test-names.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import { analyzeCode } from "../../analyzer.js";
+import { analyzeComponent } from "../../component-analyzer.js";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse, TestNameSuggestion } from "../../types.js";
+
+export const suggestTestNamesSchema = z.object({
+  filePath: absolutePathSchema.describe("분석할 소스 파일의 절대 경로"),
+});
+
+export type SuggestTestNamesInput = z.infer<typeof suggestTestNamesSchema>;
+
+// 함수용 테스트 이름 생성
+function generateFunctionTests(_name: string, params: string[]): string[] {
+  const tests: string[] = [
+    `should return expected result`,
+    `should handle empty input`,
+  ];
+
+  if (params.length > 0) {
+    tests.push(`should throw error when ${params[0]} is invalid`);
+  }
+
+  return tests;
+}
+
+// 컴포넌트용 테스트 이름 생성
+function generateComponentTests(
+  _name: string,
+  props: string[],
+  events: string[],
+  hooks: string[]
+): string[] {
+  const tests: string[] = [`should render correctly`];
+
+  // props 기반 테스트
+  for (const prop of props.slice(0, 3)) {
+    tests.push(`should render with ${prop} prop`);
+  }
+
+  // 이벤트 기반 테스트
+  for (const event of events.slice(0, 2)) {
+    const eventName = event.replace(/^on/, "").toLowerCase();
+    tests.push(`should handle ${eventName} event`);
+  }
+
+  // 커스텀 훅 기반 테스트
+  const customHooks = hooks.filter(
+    (h) =>
+      !["useState", "useEffect", "useRef", "useMemo", "useCallback"].includes(h)
+  );
+  if (customHooks.length > 0) {
+    tests.push(`should work with ${customHooks[0]}`);
+  }
+
+  return tests;
+}
+
+async function suggestNames(filePath: string): Promise<TestNameSuggestion[]> {
+  const suggestions: TestNameSuggestion[] = [];
+  const addedNames = new Set<string>(); // 중복 방지용
+
+  // 파일 확장자로 컴포넌트 여부 판단
+  const isComponent = filePath.endsWith(".tsx") || filePath.endsWith(".jsx");
+
+  if (isComponent) {
+    try {
+      const analysis = await analyzeComponent(filePath);
+      const propNames = analysis.props.map((p) => p.name);
+      const eventNames = analysis.events.map((e) => e.name);
+      const hookNames = analysis.hooks.map((h) => h.name);
+
+      suggestions.push({
+        describe: analysis.componentName,
+        tests: generateComponentTests(
+          analysis.componentName,
+          propNames,
+          eventNames,
+          hookNames
+        ),
+      });
+      addedNames.add(analysis.componentName); // 추가된 이름 기록
+    } catch {
+      // 컴포넌트 분석 실패 시 기본 코드 분석으로 폴백
+    }
+  }
+
+  // 일반 코드 분석
+  const codeAnalysis = await analyzeCode(filePath);
+
+  for (const exp of codeAnalysis.exports) {
+    // 이미 추가된 이름은 건너뛰기 (중복 방지)
+    if (addedNames.has(exp.name)) {
+      continue;
+    }
+
+    if (exp.type === "function") {
+      const paramNames = exp.params.map((p) => p.name);
+      suggestions.push({
+        describe: exp.name,
+        tests: generateFunctionTests(exp.name, paramNames),
+      });
+      addedNames.add(exp.name);
+    }
+  }
+
+  return suggestions;
+}
+
+export async function runSuggestTestNames(
+  input: SuggestTestNamesInput
+): Promise<McpToolResponse> {
+  const { filePath } = input;
+  const result = await suggestNames(filePath);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -1,0 +1,107 @@
+// 테스트 프레임워크
+export type TestFramework = "vitest" | "jest" | "unknown";
+
+// 테스트 환경 정보
+export interface TestEnvironment {
+  framework: TestFramework;
+  hasTestingLibrary: boolean;
+  testFilePattern: string;
+  configFile: string | null;
+}
+
+// 파라미터 정보
+export interface ParamInfo {
+  name: string;
+  type: string;
+}
+
+// Export 정보
+export interface ExportInfo {
+  name: string;
+  type: "function" | "component" | "hook" | "const";
+  params: ParamInfo[];
+  returnType: string;
+}
+
+// 코드 분석 결과
+export interface CodeAnalysis {
+  fileName: string;
+  fileExtension: string;
+  exports: ExportInfo[];
+  dependencies: string[];
+}
+
+// Props 정보
+export interface PropInfo {
+  name: string;
+  type: string;
+  required: boolean;
+  defaultValue?: string;
+}
+
+// Hook 정보
+export interface HookInfo {
+  name: string;
+  isCustom: boolean; // use로 시작하지만 React 내장 아닌 경우
+}
+
+// Event Handler 정보
+export interface EventInfo {
+  name: string;
+  handlerName: string;
+}
+
+// 컴포넌트 분석 결과
+export interface ComponentAnalysis {
+  componentName: string;
+  props: PropInfo[];
+  hooks: HookInfo[];
+  events: EventInfo[];
+  hasChildren: boolean;
+  isForwardRef: boolean;
+  isMemo: boolean;
+}
+
+// 유사 테스트 검색 결과
+export interface SimilarTest {
+  filePath: string;
+  similarity: "high" | "medium" | "low";
+  reason: string;
+}
+
+// MCP Tool 응답 타입
+export interface McpToolResponse {
+  [key: string]: unknown;
+  content: Array<{
+    type: "text";
+    text: string;
+  }>;
+}
+
+// 접근성 제안 항목
+export interface A11ySuggestion {
+  type: "aria" | "keyboard" | "contrast" | "focus";
+  element?: string;
+  suggestion: string;
+}
+
+// 접근성 분석 결과
+export interface A11yAnalysis {
+  hasIssues: boolean;
+  suggestions: A11ySuggestion[];
+  jestAxeExample: string;
+}
+
+// 테스트 갭 분석 결과
+export interface TestGapAnalysis {
+  sourceFile: string;
+  testFile: string | null;
+  tested: string[];
+  untested: string[];
+}
+
+// 테스트 이름 제안 결과
+export interface TestNameSuggestion {
+  describe: string;
+  tests: string[];
+}

--- a/packages/mcp-server/src/utils/constants.ts
+++ b/packages/mcp-server/src/utils/constants.ts
@@ -1,0 +1,17 @@
+export const VITEST_CONFIGS = [
+  "vitest.config.ts",
+  "vitest.config.js",
+  "vitest.config.mts",
+];
+
+export const JEST_CONFIGS = [
+  "jest.config.js",
+  "jest.config.ts",
+  "jest.config.json",
+];
+
+export const NPX_BIN = process.platform === "win32" ? "npx.cmd" : "npx";
+
+// eslint no-control-regex 우회: \x1b(ESC) 를 String.fromCharCode로 생성
+const ESC = String.fromCharCode(27);
+export const ANSI_REGEX = new RegExp(`${ESC}\\[[0-9;]*m`, "g");

--- a/packages/mcp-server/src/utils/detect-framework.ts
+++ b/packages/mcp-server/src/utils/detect-framework.ts
@@ -1,0 +1,38 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { TestFramework } from "../types.js";
+import { VITEST_CONFIGS, JEST_CONFIGS } from "./constants.js";
+
+export async function detectFramework(
+  projectPath: string
+): Promise<TestFramework> {
+  for (const config of VITEST_CONFIGS) {
+    if (existsSync(join(projectPath, config))) {
+      return "vitest";
+    }
+  }
+
+  for (const config of JEST_CONFIGS) {
+    if (existsSync(join(projectPath, config))) {
+      return "jest";
+    }
+  }
+
+  try {
+    const pkgPath = join(projectPath, "package.json");
+    const content = await readFile(pkgPath, "utf-8");
+    const pkg = JSON.parse(content) as Record<string, unknown>;
+    const deps = {
+      ...(pkg["dependencies"] as Record<string, unknown> | undefined),
+      ...(pkg["devDependencies"] as Record<string, unknown> | undefined),
+    };
+
+    if (deps["vitest"]) return "vitest";
+    if (deps["jest"]) return "jest";
+  } catch {
+    // 무시
+  }
+
+  return "unknown";
+}

--- a/packages/mcp-server/src/utils/find-project-root.ts
+++ b/packages/mcp-server/src/utils/find-project-root.ts
@@ -1,0 +1,28 @@
+import { existsSync, statSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+
+const MONOREPO_MARKERS = ["pnpm-workspace.yaml", "turbo.json"];
+
+export function findProjectRoot(startPath: string): string | null {
+  let dir = startPath;
+
+  try {
+    if (!statSync(dir).isDirectory()) {
+      dir = dirname(startPath);
+    }
+  } catch {
+    dir = dirname(startPath);
+  }
+
+  const root = parse(dir).root;
+  while (dir !== root) {
+    for (const marker of MONOREPO_MARKERS) {
+      if (existsSync(join(dir, marker))) {
+        return dir;
+      }
+    }
+    dir = dirname(dir);
+  }
+
+  return null;
+}

--- a/packages/mcp-server/src/utils/format-results.ts
+++ b/packages/mcp-server/src/utils/format-results.ts
@@ -1,0 +1,24 @@
+import type { RunTestsOutput } from "../tools/test/run-tests.js";
+
+/**
+ * AI 토큰 절약을 위한 적응형 포맷팅
+ * - 전부 pass → results 생략, summary만 반환
+ * - 실패 있음 → 실패만 상세, 성공은 name+status만
+ */
+export function formatResults(output: RunTestsOutput): RunTestsOutput {
+  if (output.summary.failed === 0) {
+    return {
+      ...output,
+      results: [],
+    };
+  }
+
+  return {
+    ...output,
+    results: output.results.map((r) =>
+      r.status === "failed"
+        ? r
+        : { name: r.name, status: r.status, duration: 0 }
+    ),
+  };
+}

--- a/packages/mcp-server/src/utils/index.ts
+++ b/packages/mcp-server/src/utils/index.ts
@@ -1,0 +1,7 @@
+export { VITEST_CONFIGS, JEST_CONFIGS } from "./constants.js";
+export { findProjectRoot } from "./find-project-root.js";
+export { detectFramework } from "./detect-framework.js";
+export { parseErrorMessage } from "./parse-error-message.js";
+export { parseStackTrace, extractLocation } from "./parse-stack-trace.js";
+export { readSourceContext } from "./read-source-context.js";
+export { formatResults } from "./format-results.js";

--- a/packages/mcp-server/src/utils/parse-error-message.ts
+++ b/packages/mcp-server/src/utils/parse-error-message.ts
@@ -1,0 +1,74 @@
+import type { TestErrorInfo } from "../tools/test/run-tests.js";
+import { parseStackTrace } from "./parse-stack-trace.js";
+import { ANSI_REGEX } from "./constants.js";
+
+/**
+ * vitest/jest의 failureMessage에서 expected, actual 값을 추출
+ *
+ * 지원 패턴:
+ * 1. Expected [label]: "value" / Received [label]: "value"
+ *    - Expected: "hello" / Received: "world"
+ *    - Expected substring: "xyz" / Received string: "hello world"
+ *    - Expected value: 4 / Received array: [1, 2, 3]
+ *    - Expected length: 3 / Received length: 2
+ *    - Expected pattern: /xyz/ / Received string: "hello world"
+ * 2. expected 'actual' to <matcher> 'expected'
+ * 3. expected {actual} to <matcher> {expected}
+ * 4. expected <actual> to <matcher> <expected>
+ */
+export function parseErrorMessage(failureMessage: string): TestErrorInfo {
+  const cleanMessage = failureMessage.replace(ANSI_REGEX, "");
+
+  const result: TestErrorInfo = {
+    message: cleanMessage,
+    stack: parseStackTrace(failureMessage),
+  };
+
+  // 패턴 1: Expected [label]: "value" / Received [label]: "value"
+  const expectedMatch = cleanMessage.match(
+    /Expected(?:\s+\w+)*:\s*(?:"([^"]+)"|'([^']+)'|(\S+))/i
+  );
+  const receivedMatch = cleanMessage.match(
+    /Received(?:\s+\w+)*:\s*(?:"([^"]+)"|'([^']+)'|(\S+))/i
+  );
+
+  if (expectedMatch || receivedMatch) {
+    if (expectedMatch) {
+      result.expected =
+        expectedMatch[1] ?? expectedMatch[2] ?? expectedMatch[3];
+    }
+    if (receivedMatch) {
+      result.actual = receivedMatch[1] ?? receivedMatch[2] ?? receivedMatch[3];
+    }
+    return result;
+  }
+
+  // 패턴 2: expected 'actual' to <matcher> 'expected' (문자열)
+  const quotedMatch = cleanMessage.match(/expected '([^']*)' to .+ '([^']*)'/i);
+  if (quotedMatch) {
+    result.actual = quotedMatch[1];
+    result.expected = quotedMatch[2];
+    return result;
+  }
+
+  const firstLine = cleanMessage.split("\n")[0] ?? "";
+  const cleaned = firstLine.replace(/\s*\/\/.*$/, "");
+
+  // 패턴 3: expected {actual} to <matcher> {expected} (객체)
+  const objectMatch = cleaned.match(/expected (\{.+\}) to .+ (\{.+\})$/i);
+  if (objectMatch) {
+    result.actual = objectMatch[1];
+    result.expected = objectMatch[2];
+    return result;
+  }
+
+  // 패턴 4: expected <actual> to <matcher> <expected> (숫자, boolean 등)
+  const generalMatch = cleaned.match(/expected (.+) to .+ (\S+)$/i);
+  if (generalMatch) {
+    result.actual = generalMatch[1];
+    result.expected = generalMatch[2];
+    return result;
+  }
+
+  return result;
+}

--- a/packages/mcp-server/src/utils/parse-stack-trace.ts
+++ b/packages/mcp-server/src/utils/parse-stack-trace.ts
@@ -1,0 +1,51 @@
+import type { TestLocation } from "../tools/test/run-tests.js";
+import { ANSI_REGEX } from "./constants.js";
+
+/**
+ * failureMessage에서 스택 트레이스를 추출하고 정리
+ * - ANSI escape 코드 제거
+ * - node_modules, node:internal 라인 필터링
+ * - 프로젝트 내부 경로만 남김
+ */
+export function parseStackTrace(failureMessage: string): string[] {
+  const cleaned = failureMessage.replace(ANSI_REGEX, "");
+  const lines = cleaned.split("\n");
+
+  return lines
+    .filter((line) => line.trimStart().startsWith("at "))
+    .filter(
+      (line) =>
+        !line.includes("node_modules") && !line.includes("node:internal")
+    );
+}
+
+/**
+ * 정리된 스택에서 첫 번째 프레임의 file:line:column 추출
+ */
+export function extractLocation(
+  stack: string[]
+): Pick<TestLocation, "line" | "column"> | null {
+  if (stack.length === 0) return null;
+
+  const frame = stack.find((f) => !f.includes("eval"));
+  if (!frame) return null;
+
+  // file:line:column (컬럼 있음)
+  const fullMatch = frame.match(/:(\d+):(\d+)\)?$/);
+  if (fullMatch) {
+    return {
+      line: Number(fullMatch[1]),
+      column: Number(fullMatch[2]),
+    };
+  }
+
+  // file:line (컬럼 없음)
+  const lineOnly = frame.match(/:(\d+)\)?$/);
+  if (lineOnly) {
+    return {
+      line: Number(lineOnly[1]),
+    };
+  }
+
+  return null;
+}

--- a/packages/mcp-server/src/utils/read-source-context.ts
+++ b/packages/mcp-server/src/utils/read-source-context.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+
+const CONTEXT_LINES = 3;
+
+/**
+ * 실패 라인 기준 ±3줄을 읽어서 컨텍스트 문자열로 반환
+ * 실패 라인에 > 마커 표시
+ */
+export function readSourceContext(
+  filePath: string,
+  line: number
+): string | null {
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.split("\n");
+
+    const start = Math.max(0, line - 1 - CONTEXT_LINES);
+    const end = Math.min(lines.length, line + CONTEXT_LINES);
+
+    return lines
+      .slice(start, end)
+      .map((text, i) => {
+        const lineNum = start + i + 1;
+        const marker = lineNum === line ? ">" : " ";
+        return `${marker} ${String(lineNum).padStart(4)} | ${text}`;
+      })
+      .join("\n");
+  } catch {
+    return null;
+  }
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/__tests__/**"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,22 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.24)(jsdom@28.0.0)
 
+  packages/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@3.25.76)
+      '@typescript-eslint/typescript-estree':
+        specifier: ^8.52.0
+        version: 8.59.4(typescript@5.9.2)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.3
+        version: 25.9.0
+
   packages/utils: {}
 
 packages:
@@ -882,6 +898,12 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1193,6 +1215,16 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.22':
     resolution: {integrity: sha512-JQZdnDNm8o43A5GOzwN/0Tz3CDBQtBUNqzVwEopm32uayjdjxev1Csp1JeaqF3v9djLDIvsSE39ecsN2LhCKKQ==}
@@ -1845,6 +1877,9 @@ packages:
   '@types/node@20.19.24':
     resolution: {integrity: sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==}
 
+  '@types/node@25.9.0':
+    resolution: {integrity: sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -1889,6 +1924,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.46.3':
     resolution: {integrity: sha512-FCi7Y1zgrmxp3DfWfr+3m9ansUUFoy8dkEdeQSgA9gbm8DaHYvZCdkFRQrtKiedFf3Ha6VmoqoAaP68+i+22kg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1898,6 +1939,12 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@8.46.3':
     resolution: {integrity: sha512-ZPCADbr+qfz3aiTTYNNkCbUt+cjNwI/5McyANNrFBpVxPt7GqpEYz5ZfdwuFyGUnJ9FdDXbGODUu6iRCI6XRXw==}
@@ -1910,11 +1957,21 @@ packages:
     resolution: {integrity: sha512-G7Ok9WN/ggW7e/tOf8TQYMaxgID3Iujn231hfi0Pc7ZheztIJVpO44ekY00b7akqc6nZcvregk0Jpah3kep6hA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.46.3':
     resolution: {integrity: sha512-f/NvtRjOm80BtNM5OQtlaBdM5BRFUv7gf381j9wygDNL+qOYSNOgtQ/DCndiYi80iIOv76QqaTmp4fa9hwI0OA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/utils@8.46.3':
     resolution: {integrity: sha512-VXw7qmdkucEx9WkmR3ld/u6VhRyKeiF1uxWwCy/iuNfokjJ7VhsgLSOTjsol8BunSw190zABzpwdNsze2Kpo4g==}
@@ -1925,6 +1982,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.46.3':
     resolution: {integrity: sha512-uk574k8IU0rOF/AjniX8qbLSGURJVUCeM5e4MIMKBFFi8weeiLrG1fyQejyLXQpRZbU/1BuQasleV/RfHC3hHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.2':
@@ -2087,6 +2148,10 @@ packages:
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
     engines: {node: '>=14.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2105,8 +2170,19 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2229,6 +2305,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -2241,11 +2321,19 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2260,6 +2348,10 @@ packages:
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2400,9 +2492,33 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -2647,6 +2763,10 @@ packages:
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2687,6 +2807,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
@@ -2695,6 +2818,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -2759,6 +2886,9 @@ packages:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2854,6 +2984,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.1:
     resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2920,6 +3054,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -2927,6 +3073,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
@@ -2958,6 +3114,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2980,6 +3139,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -3013,6 +3176,14 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -3183,6 +3354,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hono@4.12.19:
+    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3192,6 +3367,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -3233,6 +3412,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.6:
     resolution: {integrity: sha512-gtGXVaBdl5mAes3rPcMedEBm12ibjt1kDMFfheul1wUAOVEJW60voNdMVzVkfLN06O7ZaD/rxhfKgtlgtTbMjg==}
 
@@ -3246,6 +3428,14 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3354,6 +3544,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3435,6 +3628,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -3470,6 +3666,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3670,6 +3872,14 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -3798,9 +4008,21 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3981,6 +4203,13 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -4063,6 +4292,10 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -4084,6 +4317,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4116,6 +4352,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -4190,15 +4430,31 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -4380,6 +4636,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4424,6 +4684,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -4438,6 +4706,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -4523,6 +4794,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -4693,6 +4968,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
@@ -4716,6 +4995,12 @@ packages:
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -4802,6 +5087,10 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4839,6 +5128,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.20.0:
     resolution: {integrity: sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==}
@@ -4893,6 +5185,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -4907,6 +5203,10 @@ packages:
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -5138,6 +5438,9 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -5157,6 +5460,11 @@ packages:
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@3.5.4:
     resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
@@ -5735,6 +6043,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  '@hono/node-server@1.19.14(hono@4.12.19)':
+    dependencies:
+      hono: 4.12.19
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -6022,6 +6334,28 @@ snapshots:
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.19)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.19
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.22':
     optional: true
@@ -6588,6 +6922,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@25.9.0':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.26)':
@@ -6646,12 +6984,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.59.4(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.2)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.46.3':
     dependencies:
       '@typescript-eslint/types': 8.46.3
       '@typescript-eslint/visitor-keys': 8.46.3
 
   '@typescript-eslint/tsconfig-utils@8.46.3(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
@@ -6669,6 +7020,8 @@ snapshots:
 
   '@typescript-eslint/types@8.46.3': {}
 
+  '@typescript-eslint/types@8.59.4': {}
+
   '@typescript-eslint/typescript-estree@8.46.3(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/project-service': 8.46.3(typescript@5.9.2)
@@ -6681,6 +7034,21 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.7.3
       ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.4(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.2)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -6700,6 +7068,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.3
       eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
 
   '@typescript/vfs@1.6.2(typescript@5.9.2)':
     dependencies:
@@ -6853,6 +7226,11 @@ snapshots:
 
   '@xmldom/xmldom@0.9.8': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -6865,12 +7243,23 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -7001,6 +7390,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -7014,6 +7405,20 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.0
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -7022,6 +7427,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -7035,6 +7444,8 @@ snapshots:
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -7164,7 +7575,22 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -7445,6 +7871,8 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.2
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
@@ -7480,11 +7908,15 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ee-first@1.1.1: {}
+
   emoji-regex-xs@1.0.0: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   enquirer@2.4.1:
     dependencies:
@@ -7694,6 +8126,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -7835,6 +8269,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.39.1:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
@@ -7935,6 +8371,14 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -7948,6 +8392,44 @@ snapshots:
       strip-final-newline: 3.0.0
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.7: {}
 
@@ -7981,6 +8463,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.2: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -8000,6 +8484,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@4.1.0:
     dependencies:
@@ -8036,6 +8531,10 @@ snapshots:
       signal-exit: 4.1.0
 
   format@0.2.2: {}
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -8318,6 +8817,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  hono@4.12.19: {}
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.11.0
@@ -8327,6 +8828,14 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -8365,6 +8874,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.6: {}
 
   internal-slot@1.1.0:
@@ -8376,6 +8887,10 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -8478,6 +8993,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -8565,6 +9082,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jose@6.2.3: {}
+
   joycon@3.1.1: {}
 
   js-tokens@10.0.0: {}
@@ -8611,6 +9130,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -8932,6 +9455,10 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -9249,7 +9776,17 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-fn@4.0.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@3.1.2:
     dependencies:
@@ -9483,6 +10020,14 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -9583,6 +10128,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
@@ -9597,6 +10144,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -9615,6 +10164,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -9684,11 +10235,29 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.0
+      unpipe: 1.0.0
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -9993,6 +10562,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -10041,6 +10620,31 @@ snapshots:
 
   semver@7.7.3: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
@@ -10064,6 +10668,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.33.5:
     dependencies:
@@ -10208,6 +10814,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -10385,6 +10993,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.22
@@ -10404,6 +11014,10 @@ snapshots:
   trough@2.2.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+
+  ts-api-utils@2.5.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
 
@@ -10491,6 +11105,12 @@ snapshots:
 
   type-detect@4.1.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -10547,6 +11167,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici-types@7.24.6: {}
 
   undici@7.20.0: {}
 
@@ -10629,6 +11251,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -10662,6 +11286,8 @@ snapshots:
       react: 18.3.1
 
   uuid@11.1.0: {}
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -10900,6 +11526,8 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.2
 
+  wrappy@1.0.2: {}
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -10909,6 +11537,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-validation-error@3.5.4(zod@3.25.76):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "./packages/components" },
     { "path": "./packages/utils" },
     { "path": "./apps/docs" },
-    { "path": "./apps/playground" }
+    { "path": "./apps/playground" },
+    { "path": "./packages/mcp-server" }
   ]
 }


### PR DESCRIPTION
## Summary

  - `packages/mcp-server` 패키지를 모노레포에 추가하고, `frontend-mcp-kit/test-toolkit`의 코드를 복사+적응하여 MCP 서버 기반을 완성
  - 오케스트레이터 Phase 1(패키지 스캐폴드) + Phase 2(코드 이식) 완료
  - 이후 이슈(훅/컴포넌트 도구 구현)가 이 패키지 위에서 진행됨

  ## 변경 내용

  ### 패키지 스캐폴드
  - `package.json` — @modelcontextprotocol/sdk, zod, @typescript-eslint/typescript-estree 의존성
  - `tsconfig.json` — tsconfig.base.json 상속, composite 빌드
  - 도메인 디렉토리: `tools/hooks/`, `tools/components/`, `tools/test/`, `runners/`, `utils/`

  ### 코드 이식 (frontend-mcp-kit → frontend-toolkit)
  - **코어 모듈** (5개): types, schemas, analyzer, component-analyzer, detector
  - **유틸리티** (8개): find-project-root(모노레포 마커 재작성), format-results, parse-error-message 등
  - **러너** (3개): vitest-runner, jest-runner, barrel export
  - **MCP 도구** (9개): detect-test-environment, analyze-code, scaffold-test, run-tests 등
  - **엔트리포인트**: McpServer + StdioServerTransport, 9개 도구 registerTool 등록

  ### 경로 적응
  - `tools/` → `tools/test/` 이동에 따른 import 깊이 조정 (`../` → `../../`)
  - `find-project-root.ts`를 `pnpm-workspace.yaml` / `turbo.json` 기반으로 재작성
  - 테스트 파일의 `process.cwd()` 경로에 `packages/mcp-server/` 접두사 추가
  - 인라인 `findProjectRoot` 함수를 공유 유틸로 교체 (scaffold-test, find-similar-tests)

  ### 엄격한 tsconfig/eslint 대응
  - `verbatimModuleSyntax: true` → 타입 전용 import에 `import type` 적용
  - `noUncheckedIndexedAccess: true` → 배열 인덱싱에 `?? ""`, `?.[n]` 처리
  - `@typescript-eslint/no-unsafe-enum-comparison` → AST_NODE_TYPES enum 사용
  - `JSON.parse` 반환값에 타입 단언 추가

  ## 검증 결과

  | 항목 | 결과 |
  |------|------|
  | `pnpm install` | ✅ 통과 |
  | `npx tsc --noEmit` (전체) | ✅ 에러 0개 |
  | `npx eslint packages/mcp-server/src/` | ✅ 에러 0개 |
  | MCP 서버 테스트 | ✅ 207/208 통과 (1건 의도적 실패 픽스처) |
  | 기존 패키지 테스트 (hooks, components, utils) | ✅ 106/106 통과 |

  ## Test plan

  - [x] `pnpm install` 정상 동작
  - [x] `npx tsc --noEmit -p packages/mcp-server/tsconfig.json` 에러 0개
  - [x] `npx eslint packages/mcp-server/src/` 에러 0개
  - [x] `npx vitest run packages/mcp-server/src/__tests__/` 통과 (의도적 실패 1건 제외)
  - [x] `npx vitest run` 전체 테스트 기존 패키지 영향 없음