### PR TITLE
feat: MCP 서버 훅/컴포넌트 도구 구현 (list, scaffold, validate, register, review)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "frontend-toolkit": {
+      "command": "node",
+      "args": ["./packages/mcp-server/dist/index.js"]
+    }
+  }
+}

--- a/packages/mcp-server/src/__tests__/tools/get-hook-details.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/get-hook-details.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  getHookDetailsSchema,
+  runGetHookDetails,
+} from "../../tools/hooks/get-hook-details.js";
+import { join } from "node:path";
+
+describe("getHookDetailsSchema", () => {
+  it("should accept valid input", () => {
+    const result = getHookDetailsSchema.safeParse({
+      hookName: "useCalendar",
+      hooksDir: "/Users/test/packages/hooks/src",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept any string for hookName (validation in handler)", () => {
+    const result = getHookDetailsSchema.safeParse({
+      hookName: "calendar",
+      hooksDir: "/Users/test/packages/hooks/src",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("runGetHookDetails", () => {
+  const hooksDir = join(process.cwd(), "packages/hooks/src");
+
+  it("should return hook details for useCalendar", async () => {
+    const result = await runGetHookDetails({
+      hookName: "useCalendar",
+      hooksDir,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      name: string;
+      exports: Array<{ name: string }>;
+      dependencies: string[];
+      reactHooks: string[];
+    };
+
+    expect(parsed.name).toBe("useCalendar");
+    expect(parsed.exports.length).toBeGreaterThan(0);
+    expect(parsed.dependencies).toContain("react");
+  });
+
+  it("should detect React hooks used inside", async () => {
+    const result = await runGetHookDetails({
+      hookName: "useCalendar",
+      hooksDir,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      reactHooks: string[];
+    };
+
+    expect(parsed.reactHooks).toContain("useState");
+    expect(parsed.reactHooks).toContain("useMemo");
+    expect(parsed.reactHooks).toContain("useCallback");
+  });
+
+  it("should return INVALID_NAME for invalid hook name", async () => {
+    const result = await runGetHookDetails({
+      hookName: "calendar",
+      hooksDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("INVALID_NAME");
+  });
+
+  it("should return HOOK_NOT_FOUND for non-existent hook", async () => {
+    const result = await runGetHookDetails({
+      hookName: "useNonExistent",
+      hooksDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("HOOK_NOT_FOUND");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/list-components.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/list-components.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  listComponentsSchema,
+  runListComponents,
+} from "../../tools/components/list-components.js";
+import { join } from "node:path";
+
+describe("listComponentsSchema", () => {
+  it("should accept valid absolute path", () => {
+    const result = listComponentsSchema.safeParse({
+      componentsDir: "/Users/test/packages/components/src",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = listComponentsSchema.safeParse({
+      componentsDir: "./packages/components/src",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runListComponents", () => {
+  it("should return McpToolResponse with components list", async () => {
+    const componentsDir = join(process.cwd(), "packages/components/src");
+    const result = await runListComponents({ componentsDir });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe("text");
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      components: Array<{
+        name: string;
+        path: string;
+        hasTests: boolean;
+        hasReadme: boolean;
+      }>;
+      total: number;
+    };
+    expect(parsed.components.length).toBeGreaterThanOrEqual(2);
+
+    const names = parsed.components.map((c) => c.name);
+    expect(names).toContain("InViewTrigger");
+    expect(names).toContain("SuspenseBoundary");
+  });
+
+  it("should detect test files", async () => {
+    const componentsDir = join(process.cwd(), "packages/components/src");
+    const result = await runListComponents({ componentsDir });
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      components: Array<{ name: string; hasTests: boolean }>;
+    };
+
+    const inViewTrigger = parsed.components.find(
+      (c) => c.name === "InViewTrigger"
+    );
+    expect(inViewTrigger?.hasTests).toBe(true);
+  });
+
+  it("should return error for non-existent directory", async () => {
+    const result = await runListComponents({
+      componentsDir: "/nonexistent/components",
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("DIRECTORY_NOT_FOUND");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/list-hooks.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/list-hooks.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  listHooksSchema,
+  runListHooks,
+} from "../../tools/hooks/list-hooks.js";
+import { join } from "node:path";
+
+describe("listHooksSchema", () => {
+  it("should accept valid absolute path", () => {
+    const result = listHooksSchema.safeParse({
+      hooksDir: "/Users/test/packages/hooks/src",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject relative path", () => {
+    const result = listHooksSchema.safeParse({
+      hooksDir: "./packages/hooks/src",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("runListHooks", () => {
+  it("should return McpToolResponse with hooks list", async () => {
+    const hooksDir = join(process.cwd(), "packages/hooks/src");
+    const result = await runListHooks({ hooksDir });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe("text");
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      hooks: Array<{
+        name: string;
+        path: string;
+        hasTests: boolean;
+        hasReadme: boolean;
+      }>;
+      total: number;
+    };
+    expect(parsed.hooks.length).toBeGreaterThanOrEqual(6);
+
+    const names = parsed.hooks.map((h) => h.name);
+    expect(names).toContain("useCalendar");
+    expect(names).toContain("useDebounce");
+  });
+
+  it("should detect test files", async () => {
+    const hooksDir = join(process.cwd(), "packages/hooks/src");
+    const result = await runListHooks({ hooksDir });
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      hooks: Array<{ name: string; hasTests: boolean }>;
+    };
+
+    const useCalendar = parsed.hooks.find((h) => h.name === "useCalendar");
+    expect(useCalendar?.hasTests).toBe(true);
+  });
+
+  it("should return error for non-existent directory", async () => {
+    const result = await runListHooks({ hooksDir: "/nonexistent/hooks" });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("DIRECTORY_NOT_FOUND");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/register-hook.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/register-hook.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  registerHookSchema,
+  runRegisterHook,
+} from "../../tools/hooks/register-hook.js";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("registerHookSchema", () => {
+  it("should accept valid input", () => {
+    const result = registerHookSchema.safeParse({
+      hookName: "useCounter",
+      hooksDir: "/Users/test/packages/hooks/src",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("runRegisterHook", () => {
+  const testDir = join(tmpdir(), "register-hook-test");
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("should add export line to index.ts", async () => {
+    writeFileSync(
+      join(testDir, "index.ts"),
+      "export * from './useCalendar';\n"
+    );
+    mkdirSync(join(testDir, "useCounter"), { recursive: true });
+
+    const result = await runRegisterHook({
+      hookName: "useCounter",
+      hooksDir: testDir,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      registered: boolean;
+      hookName: string;
+    };
+    expect(parsed.registered).toBe(true);
+
+    const indexContent = readFileSync(join(testDir, "index.ts"), "utf-8");
+    expect(indexContent).toContain("export * from './useCounter'");
+  });
+
+  it("should return INVALID_NAME for invalid hook name", async () => {
+    const result = await runRegisterHook({
+      hookName: "counter",
+      hooksDir: testDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("INVALID_NAME");
+  });
+
+  it("should return INDEX_NOT_FOUND if index.ts missing", async () => {
+    mkdirSync(join(testDir, "useCounter"), { recursive: true });
+
+    const result = await runRegisterHook({
+      hookName: "useCounter",
+      hooksDir: testDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("INDEX_NOT_FOUND");
+  });
+
+  it("should return ALREADY_REGISTERED if already exported", async () => {
+    writeFileSync(
+      join(testDir, "index.ts"),
+      "export * from './useCounter';\n"
+    );
+    mkdirSync(join(testDir, "useCounter"), { recursive: true });
+
+    const result = await runRegisterHook({
+      hookName: "useCounter",
+      hooksDir: testDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("ALREADY_REGISTERED");
+  });
+
+  it("should return HOOK_NOT_FOUND if hook dir missing", async () => {
+    writeFileSync(join(testDir, "index.ts"), "");
+
+    const result = await runRegisterHook({
+      hookName: "useCounter",
+      hooksDir: testDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("HOOK_NOT_FOUND");
+  });
+
+  it("should not false-positive on similar hook names", async () => {
+    // useCounterAnimation이 있을 때 useCounter를 등록할 수 있어야 함
+    writeFileSync(
+      join(testDir, "index.ts"),
+      "export * from './useCounterAnimation';\n"
+    );
+    mkdirSync(join(testDir, "useCounter"), { recursive: true });
+
+    const result = runRegisterHook({
+      hookName: "useCounter",
+      hooksDir: testDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      registered?: boolean;
+      error?: string;
+    };
+    expect(parsed.registered).toBe(true);
+    expect(parsed.error).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/review-hook.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/review-hook.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  reviewHookSchema,
+  runReviewHook,
+} from "../../tools/hooks/review-hook.js";
+import { join } from "node:path";
+
+describe("reviewHookSchema", () => {
+  it("should accept valid input", () => {
+    const result = reviewHookSchema.safeParse({
+      hookName: "useCalendar",
+      hooksDir: "/Users/test/packages/hooks/src",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("runReviewHook", () => {
+  const hooksDir = join(process.cwd(), "packages/hooks/src");
+
+  it("should review an existing hook and return findings", async () => {
+    const result = await runReviewHook({
+      hookName: "useCalendar",
+      hooksDir,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      hookName: string;
+      findings: Array<{ rule: string; severity: string; message: string }>;
+      summary: { errors: number; warnings: number; suggestions: number };
+    };
+
+    expect(parsed.hookName).toBe("useCalendar");
+    expect(Array.isArray(parsed.findings)).toBe(true);
+    expect(parsed.summary).toHaveProperty("errors");
+    expect(parsed.summary).toHaveProperty("warnings");
+    expect(parsed.summary).toHaveProperty("suggestions");
+  });
+
+  it("should return INVALID_NAME for invalid hook name", async () => {
+    const result = await runReviewHook({
+      hookName: "calendar",
+      hooksDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("INVALID_NAME");
+  });
+
+  it("should return HOOK_NOT_FOUND for non-existent hook", async () => {
+    const result = await runReviewHook({
+      hookName: "useNonExistent",
+      hooksDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("HOOK_NOT_FOUND");
+  });
+
+  it("should not report memoization error for useCalendar", async () => {
+    const result = await runReviewHook({
+      hookName: "useCalendar",
+      hooksDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      findings: Array<{ rule: string; severity: string }>;
+    };
+
+    const memoErrors = parsed.findings.filter(
+      (f) => f.rule === "memoization" && f.severity === "error"
+    );
+    expect(memoErrors).toHaveLength(0);
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/scaffold-hook.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/scaffold-hook.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  scaffoldHookSchema,
+  runScaffoldHook,
+} from "../../tools/hooks/scaffold-hook.js";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("scaffoldHookSchema", () => {
+  it("should accept valid input", () => {
+    const result = scaffoldHookSchema.safeParse({
+      hookName: "useCounter",
+      hooksDir: "/Users/test/packages/hooks/src",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("runScaffoldHook", () => {
+  const testDir = join(tmpdir(), "scaffold-hook-test");
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("should create hook directory with files", async () => {
+    const result = await runScaffoldHook({
+      hookName: "useCounter",
+      hooksDir: testDir,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      created: { hookFile: string; testFile: string; indexFile: string };
+    };
+
+    expect(existsSync(parsed.created.hookFile)).toBe(true);
+    expect(existsSync(parsed.created.testFile)).toBe(true);
+    expect(existsSync(parsed.created.indexFile)).toBe(true);
+  });
+
+  it("should return INVALID_NAME for invalid hook name", async () => {
+    const result = await runScaffoldHook({
+      hookName: "counter",
+      hooksDir: testDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("INVALID_NAME");
+  });
+
+  it("should return HOOK_EXISTS if hook already exists", async () => {
+    mkdirSync(join(testDir, "useCounter"), { recursive: true });
+
+    const result = await runScaffoldHook({
+      hookName: "useCounter",
+      hooksDir: testDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("HOOK_EXISTS");
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/validate-hook.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/validate-hook.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateHookSchema,
+  runValidateHook,
+} from "../../tools/hooks/validate-hook.js";
+import { join } from "node:path";
+
+describe("validateHookSchema", () => {
+  it("should accept valid input", () => {
+    const result = validateHookSchema.safeParse({
+      hookName: "useCalendar",
+      hooksDir: "/Users/test/packages/hooks/src",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept optional timeout", () => {
+    const result = validateHookSchema.safeParse({
+      hookName: "useCalendar",
+      hooksDir: "/Users/test/packages/hooks/src",
+      timeout: 60,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("runValidateHook", () => {
+  it("should return INVALID_NAME for invalid hook name", async () => {
+    const result = await runValidateHook({
+      hookName: "calendar",
+      hooksDir: "/some/path",
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("INVALID_NAME");
+  });
+
+  it("should return HOOK_NOT_FOUND for non-existent hook", async () => {
+    const hooksDir = join(process.cwd(), "packages/hooks/src");
+    const result = await runValidateHook({
+      hookName: "useNonExistent",
+      hooksDir,
+    });
+    const parsed = JSON.parse(result.content[0]!.text) as { error: string };
+    expect(parsed.error).toBe("HOOK_NOT_FOUND");
+  });
+
+  it("should run tests for existing hook with test file", async () => {
+    const hooksDir = join(process.cwd(), "packages/hooks/src");
+    const result = await runValidateHook({
+      hookName: "useCalendar",
+      hooksDir,
+    });
+
+    const parsed = JSON.parse(result.content[0]!.text) as {
+      success: boolean;
+      hookName: string;
+      summary: { total: number; passed: number };
+    };
+
+    expect(parsed.hookName).toBe("useCalendar");
+    expect(parsed.success).toBe(true);
+    expect(parsed.summary.total).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -28,6 +28,31 @@ import {
   suggestTestNamesSchema,
 } from "./tools/test/suggest-test-names.js";
 import { runTests, runTestsSchema } from "./tools/test/run-tests.js";
+import { listHooksSchema, runListHooks } from "./tools/hooks/list-hooks.js";
+import {
+  getHookDetailsSchema,
+  runGetHookDetails,
+} from "./tools/hooks/get-hook-details.js";
+import {
+  listComponentsSchema,
+  runListComponents,
+} from "./tools/components/list-components.js";
+import {
+  scaffoldHookSchema,
+  runScaffoldHook,
+} from "./tools/hooks/scaffold-hook.js";
+import {
+  validateHookSchema,
+  runValidateHook,
+} from "./tools/hooks/validate-hook.js";
+import {
+  registerHookSchema,
+  runRegisterHook,
+} from "./tools/hooks/register-hook.js";
+import {
+  reviewHookSchema,
+  runReviewHook,
+} from "./tools/hooks/review-hook.js";
 
 const server = new McpServer({
   name: "frontend-toolkit",
@@ -128,6 +153,78 @@ server.registerTool(
     inputSchema: runTestsSchema,
   },
   runTests
+);
+
+// Tool 10: 훅 목록 조회
+server.registerTool(
+  "list_hooks",
+  {
+    description: "packages/hooks/src 하위의 훅 목록을 조회합니다",
+    inputSchema: listHooksSchema,
+  },
+  runListHooks
+);
+
+// Tool 11: 훅 상세 정보
+server.registerTool(
+  "get_hook_details",
+  {
+    description:
+      "특정 훅의 소스를 분석하여 파라미터, 의존성, 사용된 React 훅 목록을 반환합니다",
+    inputSchema: getHookDetailsSchema,
+  },
+  runGetHookDetails
+);
+
+// Tool 12: 컴포넌트 목록 조회
+server.registerTool(
+  "list_components",
+  {
+    description: "packages/components/src 하위의 컴포넌트 목록을 조회합니다",
+    inputSchema: listComponentsSchema,
+  },
+  runListComponents
+);
+
+// Tool 13: 훅 스캐폴딩
+server.registerTool(
+  "scaffold_hook",
+  {
+    description: "새 훅 디렉토리 + 소스 파일 + 테스트 파일을 생성합니다",
+    inputSchema: scaffoldHookSchema,
+  },
+  runScaffoldHook
+);
+
+// Tool 14: 훅 테스트 검증
+server.registerTool(
+  "validate_hook",
+  {
+    description: "훅의 테스트를 실행하고 결과를 반환합니다",
+    inputSchema: validateHookSchema,
+  },
+  runValidateHook
+);
+
+// Tool 15: 훅 barrel export 등록
+server.registerTool(
+  "register_hook",
+  {
+    description: "훅을 barrel export(index.ts)에 등록합니다",
+    inputSchema: registerHookSchema,
+  },
+  runRegisterHook
+);
+
+// Tool 16: 훅 코드 리뷰
+server.registerTool(
+  "review_hook",
+  {
+    description:
+      "훅 코드를 구조적으로 검증합니다 (네이밍, deps 배열, 메모이제이션, 조건부 훅 호출)",
+    inputSchema: reviewHookSchema,
+  },
+  runReviewHook
 );
 
 async function main(): Promise<void> {

--- a/packages/mcp-server/src/tools/components/list-components.ts
+++ b/packages/mcp-server/src/tools/components/list-components.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { errorResponse } from "../../utils/error-response.js";
+
+export const listComponentsSchema = z.object({
+  componentsDir: absolutePathSchema.describe(
+    "컴포넌트 패키지의 src 디렉토리 절대 경로 (예: /Users/.../packages/components/src)"
+  ),
+});
+
+export type ListComponentsInput = z.infer<typeof listComponentsSchema>;
+
+interface ComponentEntry {
+  name: string;
+  path: string;
+  hasTests: boolean;
+  hasReadme: boolean;
+}
+
+export function runListComponents(
+  input: ListComponentsInput
+): McpToolResponse {
+  const { componentsDir } = input;
+
+  if (!existsSync(componentsDir)) {
+    return errorResponse(
+      "DIRECTORY_NOT_FOUND",
+      `디렉토리를 찾을 수 없습니다: ${componentsDir}`
+    );
+  }
+
+  const entries = readdirSync(componentsDir);
+  const components: ComponentEntry[] = [];
+
+  for (const entry of entries) {
+    if (!/^[A-Z]/.test(entry)) continue;
+
+    const entryPath = join(componentsDir, entry);
+
+    try {
+      if (!statSync(entryPath).isDirectory()) continue;
+    } catch {
+      continue; // 삭제되었거나 접근 불가한 엔트리 무시
+    }
+
+    const files = readdirSync(entryPath);
+    components.push({
+      name: entry,
+      path: entryPath,
+      hasTests: files.some((f) => f.includes(".test.")),
+      hasReadme: files.some((f) => f.toLowerCase() === "readme.md"),
+    });
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ components, total: components.length }),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/hooks/get-hook-details.ts
+++ b/packages/mcp-server/src/tools/hooks/get-hook-details.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { errorResponse } from "../../utils/error-response.js";
+import { isValidHookName } from "../../utils/validate-hook-name.js";
+import { analyzeCode } from "../../analyzer.js";
+
+export const getHookDetailsSchema = z.object({
+  hookName: z.string().describe("훅 이름 (예: useCalendar)"),
+  hooksDir: absolutePathSchema.describe(
+    "훅 패키지의 src 디렉토리 절대 경로"
+  ),
+});
+
+export type GetHookDetailsInput = z.infer<typeof getHookDetailsSchema>;
+
+function extractReactHooks(source: string): string[] {
+  const hookCalls = new Set<string>();
+  const regex = /\b(use[A-Z]\w*)\s*\(/g;
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    if (match[1]) hookCalls.add(match[1]);
+  }
+  return [...hookCalls];
+}
+
+export async function runGetHookDetails(
+  input: GetHookDetailsInput
+): Promise<McpToolResponse> {
+  const { hookName, hooksDir } = input;
+
+  if (!isValidHookName(hookName)) {
+    return errorResponse(
+      "INVALID_NAME",
+      "훅 이름은 use로 시작하고 영숫자만 포함해야 합니다"
+    );
+  }
+
+  const hookDir = join(hooksDir, hookName);
+  if (!existsSync(hookDir)) {
+    return errorResponse(
+      "HOOK_NOT_FOUND",
+      `훅을 찾을 수 없습니다: ${hookName}`
+    );
+  }
+
+  const candidates = [`${hookName}.ts`, `${hookName}.tsx`, "index.ts"];
+  let mainFile: string | null = null;
+
+  for (const candidate of candidates) {
+    const candidatePath = join(hookDir, candidate);
+    if (existsSync(candidatePath)) {
+      mainFile = candidatePath;
+      break;
+    }
+  }
+
+  if (!mainFile) {
+    return errorResponse(
+      "HOOK_NOT_FOUND",
+      `훅 소스 파일을 찾을 수 없습니다: ${hookName}`
+    );
+  }
+
+  try {
+    const analysis = await analyzeCode(mainFile);
+    const source = await readFile(mainFile, "utf-8");
+    const reactHooks = extractReactHooks(source);
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            name: hookName,
+            mainFile,
+            exports: analysis.exports,
+            dependencies: analysis.dependencies,
+            reactHooks,
+          }),
+        },
+      ],
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResponse(
+      "PARSE_ERROR",
+      `훅 소스를 분석할 수 없습니다: ${message}`
+    );
+  }
+}

--- a/packages/mcp-server/src/tools/hooks/list-hooks.ts
+++ b/packages/mcp-server/src/tools/hooks/list-hooks.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { errorResponse } from "../../utils/error-response.js";
+
+export const listHooksSchema = z.object({
+  hooksDir: absolutePathSchema.describe(
+    "훅 패키지의 src 디렉토리 절대 경로 (예: /Users/.../packages/hooks/src)"
+  ),
+});
+
+export type ListHooksInput = z.infer<typeof listHooksSchema>;
+
+interface HookEntry {
+  name: string;
+  path: string;
+  hasTests: boolean;
+  hasReadme: boolean;
+}
+
+export function runListHooks(
+  input: ListHooksInput
+): McpToolResponse {
+  const { hooksDir } = input;
+
+  if (!existsSync(hooksDir)) {
+    return errorResponse(
+      "DIRECTORY_NOT_FOUND",
+      `디렉토리를 찾을 수 없습니다: ${hooksDir}`
+    );
+  }
+
+  const entries = readdirSync(hooksDir);
+  const hooks: HookEntry[] = [];
+
+  for (const entry of entries) {
+    if (!entry.startsWith("use")) continue;
+
+    const entryPath = join(hooksDir, entry);
+
+    try {
+      if (!statSync(entryPath).isDirectory()) continue;
+    } catch {
+      continue; // 삭제되었거나 접근 불가한 엔트리 무시
+    }
+
+    const files = readdirSync(entryPath);
+    hooks.push({
+      name: entry,
+      path: entryPath,
+      hasTests: files.some((f) => f.includes(".test.")),
+      hasReadme: files.some((f) => f.toLowerCase() === "readme.md"),
+    });
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ hooks, total: hooks.length }),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/hooks/register-hook.ts
+++ b/packages/mcp-server/src/tools/hooks/register-hook.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { errorResponse } from "../../utils/error-response.js";
+import { isValidHookName } from "../../utils/validate-hook-name.js";
+
+export const registerHookSchema = z.object({
+  hookName: z.string().describe("등록할 훅 이름 (예: useCounter)"),
+  hooksDir: absolutePathSchema.describe(
+    "훅 패키지의 src 디렉토리 절대 경로"
+  ),
+});
+
+export type RegisterHookInput = z.infer<typeof registerHookSchema>;
+
+export function runRegisterHook(
+  input: RegisterHookInput
+): McpToolResponse {
+  const { hookName, hooksDir } = input;
+
+  if (!isValidHookName(hookName)) {
+    return errorResponse(
+      "INVALID_NAME",
+      "훅 이름은 use로 시작하고 영숫자만 포함해야 합니다"
+    );
+  }
+
+  const hookDir = join(hooksDir, hookName);
+  if (!existsSync(hookDir)) {
+    return errorResponse(
+      "HOOK_NOT_FOUND",
+      `훅을 찾을 수 없습니다: ${hookName}`
+    );
+  }
+
+  const indexPath = join(hooksDir, "index.ts");
+  if (!existsSync(indexPath)) {
+    return errorResponse(
+      "INDEX_NOT_FOUND",
+      `barrel export 파일을 찾을 수 없습니다: ${indexPath}`
+    );
+  }
+
+  const content = readFileSync(indexPath, "utf-8");
+  const exportLine = `export * from './${hookName}';`;
+
+  // 정확한 export 라인 또는 훅 이름이 단어 경계로 존재하는지 확인
+  const hookPattern = new RegExp(`['"]\\./` + hookName + `['"]`);
+  if (hookPattern.test(content)) {
+    return errorResponse(
+      "ALREADY_REGISTERED",
+      `이미 등록된 훅입니다: ${hookName}`
+    );
+  }
+
+  const newContent = content.endsWith("\n")
+    ? content + exportLine + "\n"
+    : content + "\n" + exportLine + "\n";
+
+  writeFileSync(indexPath, newContent);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          registered: true,
+          hookName,
+          indexPath,
+          exportLine,
+        }),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/hooks/review-hook.ts
+++ b/packages/mcp-server/src/tools/hooks/review-hook.ts
@@ -1,0 +1,186 @@
+import { z } from "zod";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { errorResponse } from "../../utils/error-response.js";
+import { isValidHookName } from "../../utils/validate-hook-name.js";
+
+export const reviewHookSchema = z.object({
+  hookName: z.string().describe("리뷰할 훅 이름 (예: useCalendar)"),
+  hooksDir: absolutePathSchema.describe(
+    "훅 패키지의 src 디렉토리 절대 경로"
+  ),
+});
+
+export type ReviewHookInput = z.infer<typeof reviewHookSchema>;
+
+interface Finding {
+  rule: string;
+  severity: "error" | "warning" | "suggestion";
+  message: string;
+  line?: number;
+}
+
+function reviewNaming(source: string): Finding[] {
+  const findings: Finding[] = [];
+  const funcRegex = /export\s+function\s+(\w+)/g;
+  let match;
+  while ((match = funcRegex.exec(source)) !== null) {
+    if (match[1] && !match[1].startsWith("use")) {
+      findings.push({
+        rule: "naming",
+        severity: "error",
+        message: `export 함수 "${match[1]}"이 use로 시작하지 않습니다`,
+      });
+    }
+  }
+  return findings;
+}
+
+function reviewDepsArray(source: string): Finding[] {
+  const findings: Finding[] = [];
+  const lines = source.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+
+    if (/use(Effect|LayoutEffect)\s*\(/.test(line)) {
+      const nearby = lines.slice(i, Math.min(i + 10, lines.length)).join("\n");
+      if (/,\s*\[\s*\]\s*\)/.test(nearby)) {
+        findings.push({
+          rule: "deps-array",
+          severity: "warning",
+          message: `${String(i + 1)}번째 줄 근처: 빈 의존성 배열 []이 감지되었습니다. 마운트 시 1회 실행 의도가 맞는지 확인하세요.`,
+          line: i + 1,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+function reviewMemoization(source: string): Finding[] {
+  const findings: Finding[] = [];
+
+  const hasUseMemo = /\buseMemo\b/.test(source);
+  const hasUseCallback = /\buseCallback\b/.test(source);
+
+  if (/return\s*\{/.test(source) && !hasUseMemo && !hasUseCallback) {
+    findings.push({
+      rule: "memoization",
+      severity: "suggestion",
+      message:
+        "반환 객체가 useMemo로 감싸져 있지 않습니다. 리렌더링 최적화를 고려하세요.",
+    });
+  }
+
+  return findings;
+}
+
+function reviewConditionalHooks(source: string): Finding[] {
+  const findings: Finding[] = [];
+  const lines = source.split("\n");
+
+  let depth = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    const trimmed = line.trim();
+
+    if (/^(if|for|while)\s*\(/.test(trimmed)) {
+      depth++;
+    }
+
+    if (depth > 0 && /\buse[A-Z]\w*\s*\(/.test(trimmed)) {
+      findings.push({
+        rule: "conditional-hook",
+        severity: "error",
+        message: `${String(i + 1)}번째 줄: 조건문 내부에서 훅을 호출하고 있습니다. React 훅 규칙 위반입니다.`,
+        line: i + 1,
+      });
+    }
+
+    const opens = (trimmed.match(/{/g) ?? []).length;
+    const closes = (trimmed.match(/}/g) ?? []).length;
+    if (closes > opens && depth > 0) {
+      depth = Math.max(0, depth - (closes - opens));
+    }
+  }
+
+  return findings;
+}
+
+export async function runReviewHook(
+  input: ReviewHookInput
+): Promise<McpToolResponse> {
+  const { hookName, hooksDir } = input;
+
+  if (!isValidHookName(hookName)) {
+    return errorResponse(
+      "INVALID_NAME",
+      "훅 이름은 use로 시작하고 영숫자만 포함해야 합니다"
+    );
+  }
+
+  const hookDir = join(hooksDir, hookName);
+  if (!existsSync(hookDir)) {
+    return errorResponse(
+      "HOOK_NOT_FOUND",
+      `훅을 찾을 수 없습니다: ${hookName}`
+    );
+  }
+
+  const candidates = [`${hookName}.ts`, `${hookName}.tsx`, "index.ts"];
+  let mainFile: string | null = null;
+
+  for (const candidate of candidates) {
+    const candidatePath = join(hookDir, candidate);
+    if (existsSync(candidatePath)) {
+      mainFile = candidatePath;
+      break;
+    }
+  }
+
+  if (!mainFile) {
+    return errorResponse(
+      "HOOK_NOT_FOUND",
+      `훅 소스 파일을 찾을 수 없습니다: ${hookName}`
+    );
+  }
+
+  try {
+    const source = await readFile(mainFile, "utf-8");
+
+    const findings: Finding[] = [
+      ...reviewNaming(source),
+      ...reviewDepsArray(source),
+      ...reviewMemoization(source),
+      ...reviewConditionalHooks(source),
+    ];
+
+    const summary = {
+      errors: findings.filter((f) => f.severity === "error").length,
+      warnings: findings.filter((f) => f.severity === "warning").length,
+      suggestions: findings.filter((f) => f.severity === "suggestion").length,
+    };
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ hookName, mainFile, findings, summary }),
+        },
+      ],
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResponse(
+      "PARSE_ERROR",
+      `훅 소스를 읽을 수 없습니다: ${message}`
+    );
+  }
+}

--- a/packages/mcp-server/src/tools/hooks/scaffold-hook.ts
+++ b/packages/mcp-server/src/tools/hooks/scaffold-hook.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { errorResponse } from "../../utils/error-response.js";
+import { isValidHookName } from "../../utils/validate-hook-name.js";
+
+export const scaffoldHookSchema = z.object({
+  hookName: z.string().describe("생성할 훅 이름 (예: useCounter)"),
+  hooksDir: absolutePathSchema.describe(
+    "훅 패키지의 src 디렉토리 절대 경로"
+  ),
+});
+
+export type ScaffoldHookInput = z.infer<typeof scaffoldHookSchema>;
+
+function generateHookSource(hookName: string): string {
+  return `import { useState } from 'react';
+
+export function ${hookName}() {
+  // TODO: 구현
+  return {};
+}
+`;
+}
+
+function generateTestSource(hookName: string): string {
+  return `import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ${hookName} } from './${hookName}';
+
+describe('${hookName}', () => {
+  it('should be defined', () => {
+    const { result } = renderHook(() => ${hookName}());
+    expect(result.current).toBeDefined();
+  });
+});
+`;
+}
+
+function generateIndexSource(hookName: string): string {
+  return `export { ${hookName} } from './${hookName}';\n`;
+}
+
+export function runScaffoldHook(
+  input: ScaffoldHookInput
+): McpToolResponse {
+  const { hookName, hooksDir } = input;
+
+  if (!isValidHookName(hookName)) {
+    return errorResponse(
+      "INVALID_NAME",
+      "훅 이름은 use로 시작하고 영숫자만 포함해야 합니다"
+    );
+  }
+
+  const hookDir = join(hooksDir, hookName);
+  if (existsSync(hookDir)) {
+    return errorResponse("HOOK_EXISTS", `이미 존재하는 훅입니다: ${hookName}`);
+  }
+
+  const hookFile = join(hookDir, `${hookName}.ts`);
+  const testFile = join(hookDir, `${hookName}.test.ts`);
+  const indexFile = join(hookDir, "index.ts");
+
+  try {
+    mkdirSync(hookDir, { recursive: true });
+    writeFileSync(hookFile, generateHookSource(hookName));
+    writeFileSync(testFile, generateTestSource(hookName));
+    writeFileSync(indexFile, generateIndexSource(hookName));
+  } catch (err) {
+    // 부분 실패 시 생성된 디렉토리 정리
+    try {
+      rmSync(hookDir, { recursive: true, force: true });
+    } catch {
+      // cleanup 실패는 무시
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResponse(
+      "WRITE_ERROR",
+      `훅 파일 생성에 실패했습니다: ${message}`
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          created: { hookFile, testFile, indexFile },
+          hookName,
+        }),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/hooks/validate-hook.ts
+++ b/packages/mcp-server/src/tools/hooks/validate-hook.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { absolutePathSchema } from "../../schemas.js";
+import type { McpToolResponse } from "../../types.js";
+import { errorResponse } from "../../utils/error-response.js";
+import { isValidHookName } from "../../utils/validate-hook-name.js";
+import { findProjectRoot } from "../../utils/find-project-root.js";
+import { runVitest } from "../../runners/vitest-runner.js";
+
+export const validateHookSchema = z.object({
+  hookName: z.string().describe("검증할 훅 이름 (예: useCalendar)"),
+  hooksDir: absolutePathSchema.describe(
+    "훅 패키지의 src 디렉토리 절대 경로"
+  ),
+  timeout: z
+    .number()
+    .optional()
+    .default(30)
+    .describe("테스트 실행 제한 시간 (초, 기본값: 30)"),
+});
+
+export type ValidateHookInput = z.infer<typeof validateHookSchema>;
+
+export async function runValidateHook(
+  input: ValidateHookInput
+): Promise<McpToolResponse> {
+  const { hookName, hooksDir, timeout = 30 } = input;
+
+  if (!isValidHookName(hookName)) {
+    return errorResponse(
+      "INVALID_NAME",
+      "훅 이름은 use로 시작하고 영숫자만 포함해야 합니다"
+    );
+  }
+
+  const hookDir = join(hooksDir, hookName);
+  if (!existsSync(hookDir)) {
+    return errorResponse(
+      "HOOK_NOT_FOUND",
+      `훅을 찾을 수 없습니다: ${hookName}`
+    );
+  }
+
+  const files = readdirSync(hookDir);
+  const testFile = files.find((f) => f.includes(".test."));
+  if (!testFile) {
+    return errorResponse(
+      "HOOK_NOT_FOUND",
+      `테스트 파일을 찾을 수 없습니다: ${hookName}`
+    );
+  }
+
+  const testPath = join(hookDir, testFile);
+  const projectRoot = findProjectRoot(hooksDir);
+  if (!projectRoot) {
+    return errorResponse(
+      "VITEST_NOT_FOUND",
+      "프로젝트 루트를 찾을 수 없습니다"
+    );
+  }
+
+  const result = await runVitest(testPath, projectRoot, timeout);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          hookName,
+          success: result.success,
+          framework: result.framework,
+          summary: result.summary,
+          results: result.results,
+          error: result.error,
+        }),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/utils/error-response.ts
+++ b/packages/mcp-server/src/utils/error-response.ts
@@ -1,0 +1,12 @@
+import type { McpToolResponse } from "../types.js";
+
+export function errorResponse(code: string, message: string): McpToolResponse {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ error: code, message }),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/utils/index.ts
+++ b/packages/mcp-server/src/utils/index.ts
@@ -5,3 +5,5 @@ export { parseErrorMessage } from "./parse-error-message.js";
 export { parseStackTrace, extractLocation } from "./parse-stack-trace.js";
 export { readSourceContext } from "./read-source-context.js";
 export { formatResults } from "./format-results.js";
+export { errorResponse } from "./error-response.js";
+export { isValidHookName } from "./validate-hook-name.js";

--- a/packages/mcp-server/src/utils/validate-hook-name.ts
+++ b/packages/mcp-server/src/utils/validate-hook-name.ts
@@ -1,0 +1,9 @@
+/**
+ * 훅 이름이 유효한지 검증한다.
+ * - use로 시작해야 한다
+ * - use 다음에 대문자가 와야 한다
+ * - 영숫자만 포함해야 한다
+ */
+export function isValidHookName(name: string): boolean {
+  return /^use[A-Z][a-zA-Z0-9]*$/.test(name);
+}


### PR DESCRIPTION
  ### Summary

  - 기존 test-toolkit 9개 도구 위에 훅/컴포넌트 도메인 MCP 도구 7개를 추가하여 총 16개로 확장
  - 공유 유틸(`errorResponse`, `isValidHookName`) 추출로 반복 코드 제거
  - 런타임 안정성 강화: try-catch 방어, TOCTOU 대응, 부분 실패 cleanup
  - `.claude/settings.json`에 MCP 서버 연동 설정 추가

  ### 추가된 도구

  | 도구 | 유형 | 역할 |
  |------|------|------|
  | `list_hooks` | read | packages/hooks/src 하위 훅 목록 조회 |
  | `get_hook_details` | read | 특정 훅의 exports, deps, React 훅 사용 분석 |
  | `list_components` | read | packages/components/src 하위 컴포넌트 목록 조회 |
  | `scaffold_hook` | write | 새 훅 디렉토리 + 소스 + 테스트 파일 생성 |
  | `validate_hook` | write | 훅 테스트 실행 (vitest 서브프로세스) |
  | `register_hook` | write | barrel export(index.ts)에 훅 등록 |
  | `review_hook` | review | 훅 코드 구조적 검증 (네이밍, deps, 메모이제이션, 조건부 훅) |

  ### 검증 결과

  | 항목 | 결과 |
  |------|------|
  | `npx tsc --noEmit` | 에러 0개 |
  | `npx eslint packages/mcp-server/src/` | 에러 0개 |
  | MCP 서버 테스트 | 244/245 통과 (1건 의도적 실패 픽스처) |
  | 기존 패키지 회귀 | 106/106 통과 |
  | 서버 기동 + tools/list | 16개 도구 정상 반환 |

  ### 파일 변경

  **신규 (15개)**
  - `src/utils/error-response.ts`, `src/utils/validate-hook-name.ts`
  - `src/tools/hooks/` — 6개 도구 파일
  - `src/tools/components/list-components.ts`
  - `src/__tests__/tools/` — 7개 테스트 파일

  **수정 (2개)**
  - `src/utils/index.ts` — 유틸 export 추가
  - `src/index.ts` — 7개 도구 import + registerTool

  **설정 (1개)**
  - `.claude/settings.json` — MCP 서버 연동 설정